### PR TITLE
Fix: Remove non-existent font preload causing 404 error

### DIFF
--- a/apps/marketing/src/hooks/usePerformanceOptimizations.ts
+++ b/apps/marketing/src/hooks/usePerformanceOptimizations.ts
@@ -42,14 +42,8 @@ export const usePerformanceOptimizations = () => {
     `;
     document.head.appendChild(style);
 
-    // Add font preloading links
-    const preloadLink = document.createElement("link");
-    preloadLink.rel = "preload";
-    preloadLink.href = "/fonts/inter-var.woff2";
-    preloadLink.as = "font";
-    preloadLink.type = "font/woff2";
-    preloadLink.crossOrigin = "anonymous";
-    document.head.appendChild(preloadLink);
+    // Add font preloading links (removed non-existent font)
+    // Note: Using system fonts as defined in globals.css
 
     const preconnect1 = document.createElement("link");
     preconnect1.rel = "preconnect";
@@ -65,8 +59,6 @@ export const usePerformanceOptimizations = () => {
     return () => {
       // Cleanup on unmount
       if (style.parentNode) style.parentNode.removeChild(style);
-      if (preloadLink.parentNode)
-        preloadLink.parentNode.removeChild(preloadLink);
       if (preconnect1.parentNode)
         preconnect1.parentNode.removeChild(preconnect1);
       if (preconnect2.parentNode)


### PR DESCRIPTION
- Remove hardcoded reference to /fonts/inter-var.woff2 that doesn't exist
- Update cleanup function to remove preloadLink references
- Site now uses system fonts as defined in globals.css

Fixes: GET /fonts/inter-var.woff2 404 error in development server

### ➕ What does this PR do?
<!-- concise summary -->

### 🔨 Changes
- [ ] Feature / enhancement
- [ ] Bug fix
- [ ] Chore / refactor

### ✅ Checklist
- [ ] Tests added/updated
- [ ] Docs updated (or NA)
- [ ] No secrets in diff
- [ ] Linked to issue #____
- [ ] Screenshots / GIF added (UI changes)

### 🗒 Notes for reviewer
<!-- optional -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Improved initial page load performance and reliability by removing an unused font preload.
  - Eliminates redundant network requests while retaining existing preconnect optimizations.
  - Relies on system fonts for consistent rendering.
  - No user-facing design or behavior changes expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->