### PR TITLE
fix(docs): register SlideDeck components in MDXComponents

### DIFF
--- a/apps/docs/src/theme/MDXComponents.tsx
+++ b/apps/docs/src/theme/MDXComponents.tsx
@@ -1,8 +1,19 @@
 import MDXComponents from "@theme-original/MDXComponents";
 
 import { DocMetadata } from "../components/DocMetadata";
+import {
+  SlideDeck,
+  SlideSection,
+  DocumentDownload,
+  DownloadButton,
+} from "../components/Downloads";
 
 export default {
   ...MDXComponents,
   DocMetadata,
+  // Download/Slide deck components
+  SlideDeck,
+  SlideSection,
+  DocumentDownload,
+  DownloadButton,
 };


### PR DESCRIPTION
Add SlideDeck, SlideSection, DocumentDownload, and DownloadButton to the global MDX component registry so they can be used in MDX files.

### ➕ What does this PR do?
<!-- concise summary -->

### 🔨 Changes
- [ ] Feature / enhancement
- [ ] Bug fix
- [ ] Chore / refactor

### ✅ Checklist
- [ ] Tests added/updated
- [ ] Docs updated (or NA)
- [ ] No secrets in diff
- [ ] Linked to issue #____
- [ ] Screenshots / GIF added (UI changes)

### 🗒 Notes for reviewer
<!-- optional -->
