### PR TITLE
docs: update changelog with Week 48 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Documentation Platform
 
 #### PDF Download & Slide Deck Components
+
 - **feat(docs)**: Add PDF download and slide deck generation for progress reports ([#214](https://github.com/JustAGhosT/PhoenixRooivalk/pull/214))
 - **feat(docs)**: Add inline SlideDeck and SlideSection components with integrated download button
 - **feat(docs)**: Add print-to-PDF functionality with title page and print styles
@@ -18,11 +19,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **fix(docs)**: Fix download components to use CSS modules instead of Tailwind
 
 #### Week 48 Progress Report
+
 - **docs**: Add x402 Revenue Model as slide 6 in investor presentation ([#217](https://github.com/JustAGhosT/PhoenixRooivalk/pull/217))
 - **docs**: Expand x402 slide with concrete market examples (insurance, legal, regulatory)
 - **docs**: Add x402/Solana discussion point for investor meeting
 
 #### Layout & UI Improvements
+
 - **style(docs)**: Compact TOC sidebar and center content ([#218](https://github.com/JustAGhosT/PhoenixRooivalk/pull/218))
 - **feat(docs)**: Improve homepage design and add auth debugging ([#219](https://github.com/JustAGhosT/PhoenixRooivalk/pull/219))
 - **fix(docs)**: Remove duplicate header on documentation home page
@@ -30,9 +33,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **refactor(docs)**: Move GitHub to footer and add social links
 
 #### Build & Infrastructure
+
 - **fix(docs)**: Use pnpm instead of npm in netlify.toml
 - **chore**: Clean up root directory docs (delete obsolete pitch deck files, move DEPLOYMENT.md)
-
 ---
 
 ## [Previous] - November 14-24, 2025


### PR DESCRIPTION
Add Week 48 (Nov 25 - Dec 1, 2025) section:
- PDF download & slide deck components
- Week 48 progress report with x402 slides
- Layout & UI improvements
- Build & infrastructure fixes

### ➕ What does this PR do?
<!-- concise summary -->

### 🔨 Changes
- [ ] Feature / enhancement
- [ ] Bug fix
- [ ] Chore / refactor

### ✅ Checklist
- [ ] Tests added/updated
- [ ] Docs updated (or NA)
- [ ] No secrets in diff
- [ ] Linked to issue #____
- [ ] Screenshots / GIF added (UI changes)

### 🗒 Notes for reviewer
<!-- optional -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Changelog renamed to "Week 48 (Nov 25 - Dec 1, 2025)" and expanded with multi-section content: Documentation Platform updates, Week 48 progress report, Layout & UI improvements, and Build & Infrastructure notes; previous changelog entries retained and reordered.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->