### PR TITLE
Fix sign out not logging user out

### DIFF
--- a/apps/docs/src/contexts/AuthContext.tsx
+++ b/apps/docs/src/contexts/AuthContext.tsx
@@ -536,6 +536,10 @@ export function AuthProvider({
   const logout = useCallback(async () => {
     await signOut();
     setUser(null);
+    // Clear offline auth localStorage as safety net
+    if (typeof window !== "undefined") {
+      localStorage.removeItem("phoenix_offline_user");
+    }
     // Keep local progress on logout
   }, []);
 

--- a/apps/docs/src/services/cloud/azure/auth.ts
+++ b/apps/docs/src/services/cloud/azure/auth.ts
@@ -185,18 +185,22 @@ export class AzureAuthService implements IAuthService {
   }
 
   async signOut(): Promise<void> {
-    if (!this.msalInstance) return;
+    // Always clear local state, even if MSAL isn't initialized
+    this.currentUser = null;
 
-    try {
-      await this.msalInstance.logoutPopup({
-        postLogoutRedirectUri:
-          this.config?.postLogoutRedirectUri || window.location.origin,
-      });
-      this.currentUser = null;
-      this.notifyAuthStateChange(null);
-    } catch (error) {
-      console.error("Sign-out error:", error);
+    if (this.msalInstance) {
+      try {
+        await this.msalInstance.logoutPopup({
+          postLogoutRedirectUri:
+            this.config?.postLogoutRedirectUri || window.location.origin,
+        });
+      } catch (error) {
+        console.error("Sign-out error:", error);
+      }
     }
+
+    // Always notify listeners that user is signed out
+    this.notifyAuthStateChange(null);
   }
 
   getCurrentUser(): CloudUser | null {


### PR DESCRIPTION
The AzureAuthService.signOut() was returning early without clearing user state or notifying listeners when msalInstance was null. This caused users to remain logged in after clicking Sign Out.

Changes:
- Always clear currentUser and notify listeners in signOut(), regardless of MSAL initialization state
- Add safety net in AuthContext to clear offline auth localStorage

### ➕ What does this PR do?
<!-- concise summary -->

### 🔨 Changes
- [ ] Feature / enhancement
- [ ] Bug fix
- [ ] Chore / refactor

### ✅ Checklist
- [ ] Tests added/updated
- [ ] Docs updated (or NA)
- [ ] No secrets in diff
- [ ] Linked to issue #____
- [ ] Screenshots / GIF added (UI changes)

### 🗒 Notes for reviewer
<!-- optional -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved logout process to properly clear offline authentication data from browser storage for enhanced security.
  * Enhanced sign-out reliability to ensure authentication state changes are consistently communicated across the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->