### PR TITLE
Fix deploy-azure-functions workflow to allow manual triggers

### DIFF
--- a/.github/workflows/deploy-azure-functions.yml
+++ b/.github/workflows/deploy-azure-functions.yml
@@ -450,8 +450,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [validate-infrastructure, build]
     if: |
-      github.event_name == 'push' &&
-      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch') &&
+      (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') &&
       needs.validate-infrastructure.outputs.can_deploy == 'true'
     permissions:
       contents: read


### PR DESCRIPTION
The deploy job was only running on push events, skipping deployment when triggered via workflow_dispatch (manual trigger).

Updated condition to allow both:
- Push events to main branch
- Manual workflow_dispatch triggers (any branch)

### ➕ What does this PR do?
<!-- concise summary -->

### 🔨 Changes
- [ ] Feature / enhancement
- [ ] Bug fix
- [ ] Chore / refactor

### ✅ Checklist
- [ ] Tests added/updated
- [ ] Docs updated (or NA)
- [ ] No secrets in diff
- [ ] Linked to issue #____
- [ ] Screenshots / GIF added (UI changes)

### 🗒 Notes for reviewer
<!-- optional -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow configuration to support manual triggering via workflow dispatch, in addition to automatic deployments when pushing to the main branch.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->