### PR TITLE
Center-align documentation content for better readability

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,51 @@ Please ensure your code adheres to the following style guidelines:
 - Write clear, descriptive comments where necessary.
 - Ensure your code is well-documented and easy to read.
 
+### CSS Layout Standards
+
+#### Container Width Guidelines
+
+The project uses two canonical width standards:
+
+| Context | Max Width | Side Padding | Use Case |
+|---------|-----------|--------------|----------|
+| **General containers** | `1440px` (`--pr-container-max`) | `5%` | Marketing pages, dashboards, wide layouts |
+| **Documentation content** | `850px` (`--pr-content-width`) | `5%` | Long-form reading content (docs, articles) |
+
+#### Documentation Width Exception
+
+Documentation pages intentionally use a narrower `850px` max-width instead of
+the standard `1440px`. This is because:
+
+1. **Optimal line length**: 50-75 characters per line is ideal for readability
+2. **Reduced eye strain**: Shorter lines reduce horizontal eye movement
+3. **Better comprehension**: Studies show narrower text columns improve reading
+   comprehension
+
+#### Responsive Breakpoints
+
+All layouts should follow mobile-first responsive design:
+
+| Breakpoint | Width | Target |
+|------------|-------|--------|
+| Mobile | `<600px` | Small phones, full-width content |
+| Tablet | `600px - 899px` | Tablets, intermediate width |
+| Desktop | `≥900px` | Full content width applies |
+
+#### CSS Variables Reference
+
+```css
+/* General containers */
+--pr-container-max: 1440px;
+
+/* Documentation-specific */
+--pr-content-width: 850px;
+--pr-content-padding: 5%;
+```
+
+When creating new layouts, use these variables rather than hard-coded values to
+maintain consistency across the project.
+
 ## Code of Conduct
 
 Please note that this project is governed by a Code of Conduct. By

--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -117,6 +117,15 @@
   --pr-container-lg: 1024px;
   --pr-container-xl: 1280px;
   --pr-container-max: 1440px;
+
+  /* Documentation Content Width
+   * Note: Documentation uses a narrower max-width (850px) than the general
+   * container (1440px) to maintain optimal line length for readability
+   * (50-75 characters per line at base font-size). This is an intentional
+   * exception for long-form reading content. See CONTRIBUTING.md for details.
+   */
+  --pr-content-width: 850px;
+  --pr-content-padding: 5%;
 }
 
 /* ============================================
@@ -2300,16 +2309,58 @@ html {
   padding: 0 var(--pr-space-8);
 }
 
-/* Article content - centered with optimal reading width */
+/* ============================================
+   DOCUMENTATION CONTENT LAYOUT
+   Mobile-first responsive approach
+
+   Width Strategy:
+   - System standard: 1440px max container with 5% side padding
+   - Documentation exception: 850px max for optimal readability
+   - Uses min() for fluid responsive sizing
+   ============================================ */
+
+/* Article content - responsive centered layout */
 article {
-  max-width: 850px;
+  /* Mobile-first: fluid width with padding */
+  width: 100%;
+  max-width: min(var(--pr-content-width), 90vw);
+  margin: 0 auto;
+  padding: 0 var(--pr-content-padding);
+}
+
+/* Markdown content wrapper - responsive centered layout */
+.markdown {
+  /* Mobile-first: fluid width with padding */
+  width: 100%;
+  max-width: min(var(--pr-content-width), 90vw);
   margin: 0 auto;
 }
 
-/* Markdown content wrapper - centered with optimal line length */
-.markdown {
-  max-width: 850px;
-  margin: 0 auto;
+/* Mobile (<600px): Tighter constraints for small screens */
+@media (max-width: 599px) {
+  article,
+  .markdown {
+    max-width: 100%;
+    padding: 0 var(--pr-space-4);
+  }
+}
+
+/* Tablet (600px - 899px): Intermediate width */
+@media (min-width: 600px) and (max-width: 899px) {
+  article,
+  .markdown {
+    max-width: min(680px, 85vw);
+    padding: 0 var(--pr-space-6);
+  }
+}
+
+/* Desktop (≥900px): Full content width */
+@media (min-width: 900px) {
+  article,
+  .markdown {
+    max-width: var(--pr-content-width);
+    padding: 0 var(--pr-space-8);
+  }
 }
 
 /* Row layout */
@@ -2331,11 +2382,31 @@ article {
   display: none !important;
 }
 
-/* Doc item wrapper - allow centered content */
+/* Doc item wrapper - centered with fixed max-width for proper centering */
 .docItemContainer {
-  max-width: 100%;
+  width: 100%;
+  max-width: var(--pr-content-width);
   margin: 0 auto;
-  padding: 0 var(--pr-space-4);
+  padding: 0 var(--pr-content-padding);
+}
+
+/* Responsive docItemContainer */
+@media (max-width: 599px) {
+  .docItemContainer {
+    padding: 0 var(--pr-space-4);
+  }
+}
+
+@media (min-width: 600px) and (max-width: 899px) {
+  .docItemContainer {
+    padding: 0 var(--pr-space-6);
+  }
+}
+
+@media (min-width: 900px) {
+  .docItemContainer {
+    padding: 0 var(--pr-space-8);
+  }
 }
 
 /* Sidebar left */


### PR DESCRIPTION
Set max-width of 850px on article and markdown content with margin: 0 auto to center the content. This provides optimal line length (~65-75 characters) while centering the content visually on wider screens.

### ➕ What does this PR do?
<!-- concise summary -->

### 🔨 Changes
- [ ] Feature / enhancement
- [ ] Bug fix
- [ ] Chore / refactor

### ✅ Checklist
- [ ] Tests added/updated
- [ ] Docs updated (or NA)
- [ ] No secrets in diff
- [ ] Linked to issue #____
- [ ] Screenshots / GIF added (UI changes)

### 🗒 Notes for reviewer
<!-- optional -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved documentation readability by constraining article width to an optimal reading width with centered alignment, enhancing the user reading experience across all doc pages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->