### PR TITLE
Fix TypeScript error: use unauthenticated instead of unauthorized

### DIFF
--- a/apps/docs/azure-functions/src/functions/send-email.ts
+++ b/apps/docs/azure-functions/src/functions/send-email.ts
@@ -87,7 +87,7 @@ async function sendEmailHandler(
     );
 
     if (!authResult.valid) {
-      return Errors.unauthorized("Authentication required to send emails");
+      return Errors.unauthenticated("Authentication required to send emails");
     }
 
     const data = (await request.json()) as SendEmailRequest;


### PR DESCRIPTION
The Errors helper uses 'unauthenticated' method, not 'unauthorized'.

### ➕ What does this PR do?
<!-- concise summary -->

### 🔨 Changes
- [ ] Feature / enhancement
- [ ] Bug fix
- [ ] Chore / refactor

### ✅ Checklist
- [ ] Tests added/updated
- [ ] Docs updated (or NA)
- [ ] No secrets in diff
- [ ] Linked to issue #____
- [ ] Screenshots / GIF added (UI changes)

### 🗒 Notes for reviewer
<!-- optional -->
