### PR TITLE
Fix Azure deployment authentication error

### DIFF
--- a/.github/workflows/deploy-azure-functions.yml
+++ b/.github/workflows/deploy-azure-functions.yml
@@ -490,6 +490,7 @@ jobs:
           publish-profile: ${{ secrets.AZURE_FUNCTIONS_PUBLISH_PROFILE }}
           respect-funcignore: true
           scm-do-build-during-deployment: false
+          enable-oryx-build: false
 
       - name: Configure App Settings
         if: vars.CONFIGURE_APP_SETTINGS == 'true'


### PR DESCRIPTION
Add enable-oryx-build: false to the Azure Functions deploy step to completely bypass Kudu API interactions. The 401 Unauthorized error occurs because Azure has Basic Authentication disabled on the SCM site by default, and the functions-action tries to fetch app settings via Kudu even with scm-do-build-during-deployment: false.

This combination ensures pure ZIP deployment without any Kudu API calls:
- scm-do-build-during-deployment: false - prevents remote build
- enable-oryx-build: false - prevents Kudu settings fetch

### ➕ What does this PR do?
<!-- concise summary -->

### 🔨 Changes
- [ ] Feature / enhancement
- [ ] Bug fix
- [ ] Chore / refactor

### ✅ Checklist
- [ ] Tests added/updated
- [ ] Docs updated (or NA)
- [ ] No secrets in diff
- [ ] Linked to issue #____
- [ ] Screenshots / GIF added (UI changes)

### 🗒 Notes for reviewer
<!-- optional -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Azure Functions deployment configuration to disable Oryx build during deployment, optimizing the deployment process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->