### PR TITLE
Fix Azure Functions 401 error by switching to OIDC authentication

### DIFF
--- a/.github/workflows/deploy-azure-functions.yml
+++ b/.github/workflows/deploy-azure-functions.yml
@@ -72,25 +72,25 @@ jobs:
 
           # Required secrets for Azure Functions deployment
           echo "Checking required secrets..."
-          echo "🔍 Debug: Checking AZURE_FUNCTIONS_PUBLISH_PROFILE..."
-          echo "  Secret is set (boolean): ${{ secrets.AZURE_FUNCTIONS_PUBLISH_PROFILE != '' }}"
 
+          # AZURE_FUNCTIONS_PUBLISH_PROFILE is now optional (kept for backwards compatibility)
+          # Primary authentication uses AZURE_CREDENTIALS with Azure Login
           if [ -z "${{ secrets.AZURE_FUNCTIONS_PUBLISH_PROFILE }}" ]; then
-            echo "::error::AZURE_FUNCTIONS_PUBLISH_PROFILE is NOT set or is EMPTY"
-            echo "::error::This secret must contain the publish profile XML from Azure"
-            echo "::error::To fix: Download publish profile from Azure Portal and set as secret"
-            MISSING_SECRETS="${MISSING_SECRETS}AZURE_FUNCTIONS_PUBLISH_PROFILE, "
-            CAN_DEPLOY="false"
+            echo "::warning::AZURE_FUNCTIONS_PUBLISH_PROFILE is not set (optional - using AZURE_CREDENTIALS instead)"
           else
-            echo "✅ AZURE_FUNCTIONS_PUBLISH_PROFILE is configured"
+            echo "✅ AZURE_FUNCTIONS_PUBLISH_PROFILE is configured (optional)"
             CONFIGURED_SECRETS="${CONFIGURED_SECRETS}AZURE_FUNCTIONS_PUBLISH_PROFILE, "
             PRESENT_SECRETS="${PRESENT_SECRETS}AZURE_FUNCTIONS_PUBLISH_PROFILE, "
           fi
 
           if [ -z "${{ secrets.AZURE_CREDENTIALS }}" ]; then
+            echo "::error::AZURE_CREDENTIALS is NOT set or is EMPTY"
+            echo "::error::This secret must contain the Azure service principal credentials JSON"
+            echo "::error::To fix: Create a service principal and set AZURE_CREDENTIALS secret"
             MISSING_SECRETS="${MISSING_SECRETS}AZURE_CREDENTIALS, "
-            # Not blocking - publish profile is sufficient
+            CAN_DEPLOY="false"
           else
+            echo "✅ AZURE_CREDENTIALS is configured"
             CONFIGURED_SECRETS="${CONFIGURED_SECRETS}AZURE_CREDENTIALS, "
             PRESENT_SECRETS="${PRESENT_SECRETS}AZURE_CREDENTIALS, "
           fi
@@ -482,21 +482,19 @@ jobs:
         working-directory: ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}
         run: pnpm install --no-frozen-lockfile --prod
 
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
       - name: Deploy to Azure Functions
         uses: Azure/functions-action@v1
         with:
           app-name: ${{ vars.AZURE_FUNCTIONAPP_NAME }}
           package: ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}
-          publish-profile: ${{ secrets.AZURE_FUNCTIONS_PUBLISH_PROFILE }}
           respect-funcignore: true
           scm-do-build-during-deployment: false
           enable-oryx-build: false
-
-      - name: Configure App Settings
-        if: vars.CONFIGURE_APP_SETTINGS == 'true'
-        uses: azure/login@v2
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Set Environment Variables
         if: vars.CONFIGURE_APP_SETTINGS == 'true'


### PR DESCRIPTION
The 401 Unauthorized error occurs because Azure disables Basic Authentication on SCM sites by default, breaking publish-profile based deployments.

Changes:
- Add Azure Login step before deployment using AZURE_CREDENTIALS
- Remove publish-profile from functions-action (uses Azure CLI session)
- Make AZURE_CREDENTIALS required for deployment
- Make AZURE_FUNCTIONS_PUBLISH_PROFILE optional (backwards compat)
- Keep scm-do-build-during-deployment: false and enable-oryx-build: false

This uses Azure ARM-based deployment instead of Kudu SCM, which avoids the Basic Auth requirement entirely.

Required: Set AZURE_CREDENTIALS secret with service principal JSON: {
  "clientId": "<app-id>",
  "clientSecret": "<password>",
  "subscriptionId": "<subscription-id>",
  "tenantId": "<tenant-id>"
}

### ➕ What does this PR do?
<!-- concise summary -->

### 🔨 Changes
- [ ] Feature / enhancement
- [ ] Bug fix
- [ ] Chore / refactor

### ✅ Checklist
- [ ] Tests added/updated
- [ ] Docs updated (or NA)
- [ ] No secrets in diff
- [ ] Linked to issue #____
- [ ] Screenshots / GIF added (UI changes)

### 🗒 Notes for reviewer
<!-- optional -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment authentication to use AZURE_CREDENTIALS as the primary method with enhanced validation.
  * Made AZURE_FUNCTIONS_PUBLISH_PROFILE optional; deployment now requires AZURE_CREDENTIALS and includes improved error handling and logging for authentication failures.
  * Streamlined deployment configuration by consolidating authentication steps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->