### PR TITLE
Fix clear filter button layout and positioning

### DIFF
--- a/apps/docs/src/components/PhaseFilter/PhaseFilter.css
+++ b/apps/docs/src/components/PhaseFilter/PhaseFilter.css
@@ -336,18 +336,18 @@
   display: none;
 }
 
-/* Multiple filters container - Flexible wrapping layout */
+/* Multiple filters container - Inline layout with clear button */
 .sidebar-filters {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   gap: 0.375rem;
   align-items: center;
 }
 
 .sidebar-filters .phase-filter__select {
-  flex: 1 1 calc(50% - 0.375rem);
-  min-width: 80px;
-  max-width: 100%;
+  flex: 1 1 auto;
+  min-width: 70px;
+  max-width: none;
 }
 
 .sidebar-filters .phase-filter--sidebar {
@@ -357,4 +357,5 @@
 .sidebar-filters .phase-filter__clear {
   margin-top: 0;
   flex-shrink: 0;
+  margin-left: auto;
 }

--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -476,6 +476,10 @@ body,
   border-radius: var(--pr-radius-md);
   margin: 2px 0;
   transition: all var(--pr-duration-normal) var(--pr-ease);
+  /* Keep emoji icons and text on same line */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .menu__link:hover {
@@ -509,6 +513,8 @@ body,
 .menu__list .menu__list .menu__link {
   padding-left: 0.75rem;
   font-size: 0.875rem;
+  /* Allow longer nested items to wrap */
+  white-space: normal;
 }
 
 /* Remove the angle bracket pseudo-element if present and use proper styling */
@@ -535,6 +541,10 @@ body,
   display: flex;
   align-items: center;
   justify-content: space-between;
+  /* Prevent emoji icons from wrapping to separate line */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .menu__link--sublist-caret:hover::after {


### PR DESCRIPTION
- Keep clear filter button inline with dropdowns instead of wrapping below
- Prevent emoji icons in sidebar categories from appearing above text
- Use nowrap/ellipsis to keep sidebar menu items on single line

### ➕ What does this PR do?
<!-- concise summary -->

### 🔨 Changes
- [ ] Feature / enhancement
- [ ] Bug fix
- [ ] Chore / refactor

### ✅ Checklist
- [ ] Tests added/updated
- [ ] Docs updated (or NA)
- [ ] No secrets in diff
- [ ] Linked to issue #____
- [ ] Screenshots / GIF added (UI changes)

### 🗒 Notes for reviewer
<!-- optional -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined filter layout to display inline with improved spacing and clear functionality
  * Enhanced menu item text display with improved overflow and truncation handling for better readability

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->