### PR TITLE
Add skip_deploy_on_missing_secrets to Azure SWA workflows

### DIFF
--- a/.github/workflows/deploy-docs-azure.yml
+++ b/.github/workflows/deploy-docs-azure.yml
@@ -276,6 +276,7 @@ jobs:
           azure_static_web_apps_api_token:
             ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
           action: "close"
+          skip_deploy_on_missing_secrets: true
 
   deploy-functions:
     needs: [check-secrets, build-and-deploy]

--- a/.github/workflows/deploy-marketing-azure.yml
+++ b/.github/workflows/deploy-marketing-azure.yml
@@ -175,6 +175,8 @@ jobs:
           production_branch: main
           deployment_environment:
             ${{ github.event_name == 'push' && 'production' || '' }}
+          # Skip deployment gracefully if token is not configured
+          skip_deploy_on_missing_secrets: true
 
       - name: Comment on PR with preview URL
         if: github.event_name == 'pull_request'
@@ -211,3 +213,4 @@ jobs:
           deployment_token:
             ${{ secrets.AZURE_STATIC_WEB_APPS_MARKETING_API_TOKEN }}
           action: "close"
+          skip_deploy_on_missing_secrets: true


### PR DESCRIPTION
Prevents deployment failures when the AZURE_STATIC_WEB_APPS_*_API_TOKEN secrets are not configured. The build and validation steps will still run, but deployment will be skipped gracefully.

### ➕ What does this PR do?
<!-- concise summary -->

### 🔨 Changes
- [ ] Feature / enhancement
- [ ] Bug fix
- [ ] Chore / refactor

### ✅ Checklist
- [ ] Tests added/updated
- [ ] Docs updated (or NA)
- [ ] No secrets in diff
- [ ] Linked to issue #____
- [ ] Screenshots / GIF added (UI changes)

### 🗒 Notes for reviewer
<!-- optional -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment workflow resilience to gracefully skip deployments when credentials are unavailable, improving process stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->