### PR TITLE
Fix: show helpful message instead of throwing error when AI backend n…

### DIFF
--- a/apps/docs/src/services/cloud/azure/functions.ts
+++ b/apps/docs/src/services/cloud/azure/functions.ts
@@ -70,10 +70,22 @@ export class AzureFunctionsService implements IAIFunctionsService {
     }
 
     if (!this.config) {
-      throw new CloudFunctionError(
-        "Functions service not configured",
-        "unavailable",
-      );
+      // Return a graceful response instead of throwing
+      // This allows the UI to handle unconfigured state gracefully
+      return {
+        success: false,
+        offline: true,
+        answer:
+          "I'm currently unable to answer questions because the AI backend is not configured.\n\n" +
+          "**What you can do:**\n" +
+          "- Browse the documentation manually using the sidebar\n" +
+          "- Use the search feature to find specific topics\n" +
+          "- Check back later once the AI service is set up\n\n" +
+          "If you're an administrator, visit `/admin/diagnostics` to configure the AI backend.",
+        sources: [],
+        confidence: "low",
+        message: "AI backend not configured. Set AZURE_FUNCTIONS_BASE_URL.",
+      } as TOutput;
     }
 
     const url = `${this.config.baseUrl}/api/${name}`;
@@ -132,10 +144,21 @@ export class AzureFunctionsService implements IAIFunctionsService {
     }
 
     if (!this.config) {
-      throw new CloudFunctionError(
-        "Functions service not configured",
-        "unavailable",
-      );
+      // Return a graceful response instead of throwing
+      return {
+        success: false,
+        offline: true,
+        answer:
+          "I'm currently unable to answer questions because the AI backend is not configured.\n\n" +
+          "**What you can do:**\n" +
+          "- Browse the documentation manually using the sidebar\n" +
+          "- Use the search feature to find specific topics\n" +
+          "- Check back later once the AI service is set up\n\n" +
+          "If you're an administrator, visit `/admin/diagnostics` to configure the AI backend.",
+        sources: [],
+        confidence: "low",
+        message: "AI backend not configured. Set AZURE_FUNCTIONS_BASE_URL.",
+      } as TOutput;
     }
 
     if (!this.authToken) {

--- a/apps/docs/src/services/cloud/offline/index.ts
+++ b/apps/docs/src/services/cloud/offline/index.ts
@@ -625,6 +625,9 @@ export class OfflineMessagingService implements IMessagingService {
 // ============================================================================
 
 export class OfflineAIFunctionsService implements IAIFunctionsService {
+  private static readonly OFFLINE_MESSAGE =
+    "AI features require backend configuration. The assistant works best when AZURE_FUNCTIONS_BASE_URL is configured.";
+
   isConfigured(): boolean {
     return false; // AI features not available offline
   }
@@ -638,10 +641,13 @@ export class OfflineAIFunctionsService implements IAIFunctionsService {
     _data: TInput,
     _options?: any,
   ): Promise<TOutput> {
-    throw new Error(
-      "AI Functions not available. AZURE_FUNCTIONS_BASE_URL is not configured. " +
-        "Admins: Visit /admin/diagnostics for setup instructions.",
-    );
+    // Return a typed response that matches common function return types
+    // This allows the UI to handle offline mode gracefully
+    return {
+      success: false,
+      offline: true,
+      message: OfflineAIFunctionsService.OFFLINE_MESSAGE,
+    } as TOutput;
   }
 
   async callAuthenticated<TInput, TOutput>(
@@ -649,10 +655,12 @@ export class OfflineAIFunctionsService implements IAIFunctionsService {
     _data: TInput,
     _options?: any,
   ): Promise<TOutput> {
-    throw new Error(
-      "AI Functions not available. AZURE_FUNCTIONS_BASE_URL is not configured. " +
-        "Admins: Visit /admin/diagnostics for setup instructions.",
-    );
+    // Return a typed response that matches common function return types
+    return {
+      success: false,
+      offline: true,
+      message: OfflineAIFunctionsService.OFFLINE_MESSAGE,
+    } as TOutput;
   }
 
   async analyzeCompetitors(
@@ -710,7 +718,12 @@ export class OfflineAIFunctionsService implements IAIFunctionsService {
   ): Promise<RAGResponse> {
     return {
       answer:
-        "AI features are not available in offline mode. Please configure a cloud provider.",
+        "I'm currently unable to answer questions because the AI backend is not configured.\n\n" +
+        "**What you can do:**\n" +
+        "- Browse the documentation manually using the sidebar\n" +
+        "- Use the search feature to find specific topics\n" +
+        "- Check back later once the AI service is set up\n\n" +
+        "If you're an administrator, visit `/admin/diagnostics` to configure the AI backend.",
       sources: [],
       confidence: "low",
     };


### PR DESCRIPTION
…ot configured

Instead of throwing technical errors like "AZURE_FUNCTIONS_BASE_URL is not configured", the AI chat now gracefully returns a user-friendly message explaining the situation and suggesting alternatives (browse docs, use search, contact admin).

This improves UX when the Azure Functions backend isn't configured - the chat button still shows and users get helpful guidance instead of a scary error.

### ➕ What does this PR do?
<!-- concise summary -->

### 🔨 Changes
- [ ] Feature / enhancement
- [ ] Bug fix
- [ ] Chore / refactor

### ✅ Checklist
- [ ] Tests added/updated
- [ ] Docs updated (or NA)
- [ ] No secrets in diff
- [ ] Linked to issue #____
- [ ] Screenshots / GIF added (UI changes)

### 🗒 Notes for reviewer
<!-- optional -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for unconfigured cloud services with user-friendly messages instead of application errors.
  * Enhanced offline fallback responses with clearer guidance on service configuration and next steps.
  * Better error messaging in documentation and analysis features when cloud backend is unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->