### PR TITLE
Fix: Memoize arrays to prevent callback instability (React #310)

### DIFF
--- a/apps/docs/src/components/Gamification/Achievements.tsx
+++ b/apps/docs/src/components/Gamification/Achievements.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useState, useCallback } from "react";
+import { useState, useCallback, useMemo } from "react";
 import { useAuth } from "../../contexts/AuthContext";
 
 export interface Achievement {
@@ -221,10 +221,13 @@ export function useAchievements() {
     null,
   );
 
-  // Get unlocked achievements from auth context
-  const unlockedAchievements = progress?.achievements
-    ? Object.keys(progress.achievements)
-    : [];
+  // Memoize unlocked achievements to prevent callback instability
+  // Without this, a new array is created every render causing cascading updates
+  const unlockedAchievements = useMemo(
+    () =>
+      progress?.achievements ? Object.keys(progress.achievements) : [],
+    [progress?.achievements],
+  );
   const totalPoints = progress?.stats?.totalPoints || 0;
 
   const unlockAchievement = useCallback(

--- a/apps/docs/src/components/Sidebar/SidebarRecommendations.tsx
+++ b/apps/docs/src/components/Sidebar/SidebarRecommendations.tsx
@@ -99,11 +99,15 @@ export function SidebarRecommendations({
   const { knownProfile, isProfileLoaded, profileKey, confirmedRoles } =
     userProfile;
 
-  // Get selected template for unknown users
-  const selectedTemplate =
-    !knownProfile && profileKey && profileKey in PROFILE_TEMPLATES
-      ? PROFILE_TEMPLATES[profileKey]
-      : null;
+  // Memoize selected template to prevent callback instability
+  // This ensures stable references for callbacks that depend on it
+  const selectedTemplate = useMemo(
+    () =>
+      !knownProfile && profileKey && profileKey in PROFILE_TEMPLATES
+        ? PROFILE_TEMPLATES[profileKey]
+        : null,
+    [knownProfile, profileKey],
+  );
 
   // Reset state when user changes (fixes loadedRef persistence bug)
   useEffect(() => {


### PR DESCRIPTION
- Memoize unlockedAchievements array in useAchievements hook to prevent new array reference on every render
- Memoize selectedTemplate in SidebarRecommendations component to prevent cascading callback recreations

These changes ensure stable callback references which helps prevent the infinite re-render loop when userProfile loads.

### ➕ What does this PR do?
<!-- concise summary -->

### 🔨 Changes
- [ ] Feature / enhancement
- [ ] Bug fix
- [ ] Chore / refactor

### ✅ Checklist
- [ ] Tests added/updated
- [ ] Docs updated (or NA)
- [ ] No secrets in diff
- [ ] Linked to issue #____
- [ ] Screenshots / GIF added (UI changes)

### 🗒 Notes for reviewer
<!-- optional -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Implemented performance optimizations in documentation components through enhanced memoization techniques. Values computed for achievement displays and sidebar recommendations are now processed more efficiently, improving rendering responsiveness and overall system stability. These internal improvements provide a smoother user experience while maintaining all existing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->