### PR TITLE
Fix: Skip known-emails API call in offline mode

### DIFF
--- a/apps/docs/src/services/known-emails.ts
+++ b/apps/docs/src/services/known-emails.ts
@@ -4,7 +4,7 @@
  * Frontend service for managing known internal user email mappings.
  */
 
-import { getAuthService } from "./cloud";
+import { getAuthService, getCurrentProvider } from "./cloud";
 
 /**
  * Get API base URL from Docusaurus config or fallback to /api
@@ -254,6 +254,11 @@ export async function checkKnownEmail(
   email: string,
 ): Promise<{ isKnown: boolean; profileKey: string | null }> {
   if (!email) {
+    return { isKnown: false, profileKey: null };
+  }
+
+  // Skip API call in offline mode - the local fallback in internal-users.ts will handle it
+  if (getCurrentProvider() === "offline") {
     return { isKnown: false, profileKey: null };
   }
 


### PR DESCRIPTION
When the app runs in offline mode, the checkKnownEmail function was making an API call to /api/known-emails/check which returned 404 because the Azure Functions endpoint is not available in offline mode.

This fix checks if the cloud provider is "offline" and returns early with a default response, allowing the local fallback in internal-users.ts to handle email profile matching instead.

### ➕ What does this PR do?
<!-- concise summary -->

### 🔨 Changes
- [ ] Feature / enhancement
- [ ] Bug fix
- [ ] Chore / refactor

### ✅ Checklist
- [ ] Tests added/updated
- [ ] Docs updated (or NA)
- [ ] No secrets in diff
- [ ] Linked to issue #____
- [ ] Screenshots / GIF added (UI changes)

### 🗒 Notes for reviewer
<!-- optional -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced offline mode support for email verification functionality. The application now intelligently detects when operating in offline mode and avoids making unnecessary API calls during these periods. Instead, it returns appropriate fallback values to maintain stability, responsiveness, and user experience when network connectivity is unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->