### PR TITLE
Fix: Improve auth warning message in OfflineAuthService

### DIFF
--- a/apps/docs/src/services/cloud/offline/index.ts
+++ b/apps/docs/src/services/cloud/offline/index.ts
@@ -60,7 +60,11 @@ export class OfflineAuthService implements IAuthService {
   ): Promise<CloudUser | null> {
     // Do NOT create fake users - auth is not configured
     console.warn(
-      "Authentication is not configured. Please configure Azure AD to enable sign-in.",
+      "[Phoenix Auth] Authentication is not configured.\n\n" +
+        "To enable sign-in, set these environment variables:\n" +
+        "  • AZURE_ENTRA_CLIENT_ID - Your Azure AD B2C application client ID\n" +
+        "  • AZURE_ENTRA_TENANT_ID - Your Azure AD B2C tenant ID\n\n" +
+        "Then trigger a new deployment. Visit /admin/diagnostics for status.",
     );
     return null;
   }


### PR DESCRIPTION
Add helpful guidance when user clicks sign-in button but auth is not configured, showing which env vars to set and where to check status.

### ➕ What does this PR do?
<!-- concise summary -->

### 🔨 Changes
- [ ] Feature / enhancement
- [ ] Bug fix
- [ ] Chore / refactor

### ✅ Checklist
- [ ] Tests added/updated
- [ ] Docs updated (or NA)
- [ ] No secrets in diff
- [ ] Linked to issue #____
- [ ] Screenshots / GIF added (UI changes)

### 🗒 Notes for reviewer
<!-- optional -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved offline authentication error messaging to provide clearer Phoenix Auth misconfiguration guidance with specific setup instructions (AZURE_ENTRA_CLIENT_ID and AZURE_ENTRA_TENANT_ID configuration, redeploy steps, and diagnostic tool reference).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->