### PR TITLE
Fix invalid skip_deploy_on_missing_secrets input in workflow files

### DIFF
--- a/.github/workflows/deploy-docs-azure.yml
+++ b/.github/workflows/deploy-docs-azure.yml
@@ -281,12 +281,12 @@ jobs:
     name: Close Pull Request
     steps:
       - name: Close Pull Request
+        if: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN != '' }}
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token:
             ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
           action: "close"
-          skip_deploy_on_missing_secrets: true
 
   deploy-functions:
     needs: [check-secrets, build-and-deploy]

--- a/.github/workflows/deploy-marketing-azure.yml
+++ b/.github/workflows/deploy-marketing-azure.yml
@@ -161,6 +161,7 @@ jobs:
 
       - name: Deploy to Azure Static Web Apps
         id: deploy
+        if: needs.check-secrets.outputs.has-swa-token == 'true'
         uses: Azure/static-web-apps-deploy@v1
         with:
           deployment_token:
@@ -175,8 +176,6 @@ jobs:
           production_branch: main
           deployment_environment:
             ${{ github.event_name == 'push' && 'production' || '' }}
-          # Skip deployment gracefully if token is not configured
-          skip_deploy_on_missing_secrets: true
 
       - name: Comment on PR with preview URL
         if: github.event_name == 'pull_request'
@@ -208,9 +207,9 @@ jobs:
     name: Close Pull Request
     steps:
       - name: Close Pull Request
+        if: ${{ secrets.AZURE_STATIC_WEB_APPS_MARKETING_API_TOKEN != '' }}
         uses: Azure/static-web-apps-deploy@v1
         with:
           deployment_token:
             ${{ secrets.AZURE_STATIC_WEB_APPS_MARKETING_API_TOKEN }}
           action: "close"
-          skip_deploy_on_missing_secrets: true


### PR DESCRIPTION
The Azure Static Web Apps action does not support 'skip_deploy_on_missing_secrets'. Use conditional step execution with 'if' instead to skip steps when secrets are missing.

### ➕ What does this PR do?
<!-- concise summary -->

### 🔨 Changes
- [ ] Feature / enhancement
- [ ] Bug fix
- [ ] Chore / refactor

### ✅ Checklist
- [ ] Tests added/updated
- [ ] Docs updated (or NA)
- [ ] No secrets in diff
- [ ] Linked to issue #____
- [ ] Screenshots / GIF added (UI changes)

### 🗒 Notes for reviewer
<!-- optional -->
