### PR TITLE
Fix workflow secret check - use job outputs instead of direct comparison

### DIFF
--- a/.github/workflows/deploy-docs-azure.yml
+++ b/.github/workflows/deploy-docs-azure.yml
@@ -276,12 +276,13 @@ jobs:
             });
 
   close-pull-request:
+    needs: check-secrets
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     runs-on: ubuntu-latest
     name: Close Pull Request
     steps:
       - name: Close Pull Request
-        if: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN != '' }}
+        if: needs.check-secrets.outputs.has-swa-token == 'true'
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token:

--- a/.github/workflows/deploy-marketing-azure.yml
+++ b/.github/workflows/deploy-marketing-azure.yml
@@ -202,12 +202,13 @@ jobs:
             });
 
   close-pull-request:
+    needs: check-secrets
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     runs-on: ubuntu-latest
     name: Close Pull Request
     steps:
       - name: Close Pull Request
-        if: ${{ secrets.AZURE_STATIC_WEB_APPS_MARKETING_API_TOKEN != '' }}
+        if: needs.check-secrets.outputs.has-swa-token == 'true'
         uses: Azure/static-web-apps-deploy@v1
         with:
           deployment_token:


### PR DESCRIPTION
GitHub Actions doesn't allow direct secret comparisons in step 'if' conditions. Use the existing check-secrets job outputs to conditionally skip steps.

### ➕ What does this PR do?
<!-- concise summary -->

### 🔨 Changes
- [ ] Feature / enhancement
- [ ] Bug fix
- [ ] Chore / refactor

### ✅ Checklist
- [ ] Tests added/updated
- [ ] Docs updated (or NA)
- [ ] No secrets in diff
- [ ] Linked to issue #____
- [ ] Screenshots / GIF added (UI changes)

### 🗒 Notes for reviewer
<!-- optional -->
