### PR TITLE
Fix TypeScript error in aiService - remove unreachable code branch

### DIFF
--- a/apps/docs/src/services/aiService.ts
+++ b/apps/docs/src/services/aiService.ts
@@ -289,21 +289,11 @@ class AIService {
 
       const functionsService = getFunctionsService();
 
-      // Use callAuthenticated if available, otherwise fall back to call
-      if ("callAuthenticated" in functionsService) {
-        const result = await (functionsService as AzureFunctionsService).callAuthenticated<
-          Record<string, unknown>,
-          T
-        >(functionName, data);
-        this.log(`Function ${functionName} completed in ${Date.now() - startTime}ms`);
-        return result;
-      }
-
-      // Fall back to regular call (token already set via setAuthToken)
-      const result = await functionsService.call<Record<string, unknown>, T>(
-        functionName,
-        data,
-      );
+      // Use callAuthenticated which is part of the IFunctionsService interface
+      const result = await functionsService.callAuthenticated<
+        Record<string, unknown>,
+        T
+      >(functionName, data);
       this.log(`Function ${functionName} completed in ${Date.now() - startTime}ms`);
       return result;
     } catch (error) {


### PR DESCRIPTION
Since callAuthenticated is part of IFunctionsService interface, the type guard check was always true, making the fallback branch unreachable (type 'never'). Simplified by directly calling callAuthenticated.

### ➕ What does this PR do?
<!-- concise summary -->

### 🔨 Changes
- [ ] Feature / enhancement
- [ ] Bug fix
- [ ] Chore / refactor

### ✅ Checklist
- [ ] Tests added/updated
- [ ] Docs updated (or NA)
- [ ] No secrets in diff
- [ ] Linked to issue #____
- [ ] Screenshots / GIF added (UI changes)

### 🗒 Notes for reviewer
<!-- optional -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined AI service authentication by removing conditional fallback logic and enforcing a single authenticated call path.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->