### PR TITLE
Fix 401 Unauthorized - support both Azure AD B2C and multi-tenant tokens

### DIFF
--- a/infra/azure/modules/functions.bicep
+++ b/infra/azure/modules/functions.bicep
@@ -165,6 +165,11 @@ resource functionApp 'Microsoft.Web/sites@2023-01-01' = {
           name: 'AZURE_AD_B2C_POLICY'
           value: azureAdB2cPolicy
         }
+        // Also set as AZURE_ENTRA_CLIENT_ID for multi-tenant Azure AD support
+        {
+          name: 'AZURE_ENTRA_CLIENT_ID'
+          value: azureAdB2cClientId
+        }
       ]
       cors: {
         allowedOrigins: [

--- a/infra/azure/parameters.prod.json
+++ b/infra/azure/parameters.prod.json
@@ -27,7 +27,7 @@
       "value": "phoenixrooivalkb2c"
     },
     "b2cClientId": {
-      "value": ""
+      "value": "55b6aa54-8d3d-4902-8d96-81ead3b9f10c"
     },
     "b2cPolicy": {
       "value": "B2C_1_signupsignin"


### PR DESCRIPTION
- Rewrite auth.ts to detect token issuer and validate accordingly
- Add JWKS caching for both B2C and common Azure AD endpoints
- Support multi-tenant Azure AD tokens via login.microsoftonline.com/common
- Add AZURE_ENTRA_CLIENT_ID environment variable to Functions
- Configure production B2C client ID for token audience validation

### ➕ What does this PR do?
<!-- concise summary -->

### 🔨 Changes
- [ ] Feature / enhancement
- [ ] Bug fix
- [ ] Chore / refactor

### ✅ Checklist
- [ ] Tests added/updated
- [ ] Docs updated (or NA)
- [ ] No secrets in diff
- [ ] Linked to issue #____
- [ ] Screenshots / GIF added (UI changes)

### 🗒 Notes for reviewer
<!-- optional -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended authentication to support both Azure AD B2C and regular Azure AD multi-tenant scenarios with enhanced token validation.

* **Chores**
  * Updated deployment configuration with multi-tenant Azure AD client identifier for improved authentication flexibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->