### PR TITLE
Fix 401 on cosmos proxy - add auth token to requests

### DIFF
--- a/apps/docs/src/services/cloud/azure/database.ts
+++ b/apps/docs/src/services/cloud/azure/database.ts
@@ -22,6 +22,7 @@ import {
   FieldOperations,
   QueryCondition,
 } from "../interfaces/types";
+import { getAuthService } from "../index";
 
 /**
  * Azure Cosmos DB Configuration
@@ -663,13 +664,26 @@ export class AzureDatabaseService implements IDatabaseService {
     // Remove trailing slash to prevent double-slash in URL
     const baseUrl = this.config.functionsBaseUrl.replace(/\/+$/, "");
 
+    // Get auth token for the request
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+
+    try {
+      const auth = getAuthService();
+      const token = await auth.getIdToken();
+      if (token) {
+        headers["Authorization"] = `Bearer ${token}`;
+      }
+    } catch {
+      // Auth service may not be available, continue without token
+    }
+
     const response = await fetch(
       `${baseUrl}/api/cosmos/${operation}`,
       {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
+        headers,
         body: JSON.stringify(params),
       },
     );


### PR DESCRIPTION
The client-side database service was not sending the Authorization header when making requests to the cosmos proxy endpoints. Added getAuthService import and included the Bearer token in fetch headers.

### ➕ What does this PR do?
<!-- concise summary -->

### 🔨 Changes
- [ ] Feature / enhancement
- [ ] Bug fix
- [ ] Chore / refactor

### ✅ Checklist
- [ ] Tests added/updated
- [ ] Docs updated (or NA)
- [ ] No secrets in diff
- [ ] Linked to issue #____
- [ ] Screenshots / GIF added (UI changes)

### 🗒 Notes for reviewer
<!-- optional -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced cloud database authentication with automatic token-based authorization headers
  * Improved request headers for better protocol compliance and security

* **Bug Fixes**
  * Added graceful fallback mechanism when authentication is unavailable, ensuring requests continue to process

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->