### PR TITLE
Fix 404 on getLatestContentTimestamps - update route to match client

### DIFF
--- a/apps/docs/azure-functions/src/functions/support.ts
+++ b/apps/docs/azure-functions/src/functions/support.ts
@@ -194,9 +194,9 @@ app.http("submitContactForm", {
 });
 
 app.http("getLatestContentTimestamps", {
-  methods: ["GET"],
+  methods: ["GET", "POST"],
   authLevel: "anonymous",
-  route: "support/timestamps",
+  route: "getLatestContentTimestamps",
   handler: getLatestContentTimestampsHandler,
 });
 


### PR DESCRIPTION
Client calls /api/getLatestContentTimestamps but the route was support/timestamps. Updated route to match function name and added POST method support since client uses POST for all function calls.

### ➕ What does this PR do?
<!-- concise summary -->

### 🔨 Changes
- [ ] Feature / enhancement
- [ ] Bug fix
- [ ] Chore / refactor

### ✅ Checklist
- [ ] Tests added/updated
- [ ] Docs updated (or NA)
- [ ] No secrets in diff
- [ ] Linked to issue #____
- [ ] Screenshots / GIF added (UI changes)

### 🗒 Notes for reviewer
<!-- optional -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Endpoint for retrieving latest content timestamps now accepts both GET and POST requests, expanding its capabilities.

* **Changes**
  * Endpoint route renamed for improved clarity and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->