### PR TITLE
Fix cosmos 500 and known-emails 404 errors

### DIFF
--- a/apps/docs/src/services/auth.ts
+++ b/apps/docs/src/services/auth.ts
@@ -141,8 +141,8 @@ export async function signOut(): Promise<void> {
 export async function getUserProgress(userId: string): Promise<UserProgress> {
   const db = getDatabaseService();
   const data = await db.getDocument<UserProgress>(
-    `users/${userId}/progress`,
-    "current",
+    "user_progress",
+    userId,
   );
   return (
     data || {
@@ -162,8 +162,8 @@ export async function saveUserProgress(
 ): Promise<void> {
   const db = getDatabaseService();
   await db.setDocument(
-    `users/${userId}/progress`,
-    "current",
+    "user_progress",
+    userId,
     progress as unknown as Record<string, unknown>,
   );
 }

--- a/apps/docs/src/services/known-emails.ts
+++ b/apps/docs/src/services/known-emails.ts
@@ -6,8 +6,12 @@
 
 import { getAuthService, getCurrentProvider } from "./cloud";
 
+// Production Azure Functions URL fallback
+const AZURE_FUNCTIONS_FALLBACK =
+  "https://phoenix-rooivalk-functions-cjfde7dng4hsbtfk.southafricanorth-01.azurewebsites.net";
+
 /**
- * Get API base URL from Docusaurus config or fallback to /api
+ * Get API base URL from Docusaurus config or fallback to Azure Functions
  */
 function getApiBase(): string {
   if (typeof window !== "undefined") {
@@ -23,7 +27,8 @@ function getApiBase(): string {
       // Ignore
     }
   }
-  return "/api";
+  // Fallback to production Azure Functions URL
+  return AZURE_FUNCTIONS_FALLBACK;
 }
 
 const API_BASE = getApiBase();


### PR DESCRIPTION
- auth.ts: Use flat container name 'user_progress' instead of Firestore-style path 'users/{id}/progress'
- known-emails.ts: Add hardcoded Azure Functions URL fallback instead of falling back to '/api' which goes to wrong domain

### ➕ What does this PR do?
<!-- concise summary -->

### 🔨 Changes
- [ ] Feature / enhancement
- [ ] Bug fix
- [ ] Chore / refactor

### ✅ Checklist
- [ ] Tests added/updated
- [ ] Docs updated (or NA)
- [ ] No secrets in diff
- [ ] Linked to issue #____
- [ ] Screenshots / GIF added (UI changes)

### 🗒 Notes for reviewer
<!-- optional -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch `auth` user progress to `user_progress` container keyed by `userId`, and update known-emails API base to fallback to the production Azure Functions URL instead of `/api`.
> 
> - **Services**:
>   - **`apps/docs/src/services/auth.ts`**:
>     - Read/write user progress via Cosmos container `user_progress` with document ID `userId` (replacing Firestore-style `users/{id}/progress`).
>   - **`apps/docs/src/services/known-emails.ts`**:
>     - Add `AZURE_FUNCTIONS_FALLBACK` and use it as default API base when not provided by config (replacing previous `/api` fallback).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c5d058876c3ffd8f68387ced935481e0f7decc8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure Improvements**
  * Enhanced API fallback mechanism to improve service reliability and availability.
  * Optimized user progress data structure for improved system organization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->