### PR TITLE
Add production Azure Functions URL fallback

### DIFF
--- a/apps/docs/src/services/known-emails.ts
+++ b/apps/docs/src/services/known-emails.ts
@@ -6,6 +6,10 @@
 
 import { getAuthService, getCurrentProvider } from "./cloud";
 
+// Production Azure Functions URL - used when AZURE_FUNCTIONS_BASE_URL env var is not set
+const AZURE_FUNCTIONS_URL =
+  "https://phoenix-rooivalk-functions-cjfde7dng4hsbtfk.southafricanorth-01.azurewebsites.net/api";
+
 // Cached API base URL (evaluated lazily)
 let cachedApiBase: string | null = null;
 
@@ -19,7 +23,7 @@ function normalizeApiUrl(url: string): string {
 }
 
 /**
- * Get API base URL from Docusaurus config
+ * Get API base URL from Docusaurus config or production fallback
  * Evaluated lazily to ensure window.__DOCUSAURUS__ is available
  */
 function getApiBase(): string {
@@ -43,16 +47,9 @@ function getApiBase(): string {
     }
   }
 
-  // Fallback: Use window location origin with /api prefix for relative calls
-  // This works when Azure Functions are deployed as part of the same SWA
-  // or when proxied via the SWA API routing
-  if (typeof window !== "undefined") {
-    cachedApiBase = `${window.location.origin}/api`;
-    return cachedApiBase;
-  }
-
-  // SSR fallback - return empty and let the call fail gracefully
-  return "/api";
+  // Fallback to production Azure Functions URL
+  cachedApiBase = AZURE_FUNCTIONS_URL;
+  return cachedApiBase;
 }
 
 /**


### PR DESCRIPTION
### ➕ What does this PR do?
<!-- concise summary -->

### 🔨 Changes
- [ ] Feature / enhancement
- [ ] Bug fix
- [ ] Chore / refactor

### ✅ Checklist
- [ ] Tests added/updated
- [ ] Docs updated (or NA)
- [ ] No secrets in diff
- [ ] Linked to issue #____
- [ ] Screenshots / GIF added (UI changes)

### 🗒 Notes for reviewer
<!-- optional -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a hardcoded production Azure Functions base URL and updates `getApiBase()` to fall back to it when Docusaurus config is unavailable.
> 
> - **Services (`apps/docs/src/services/known-emails.ts`)**
>   - Introduces `AZURE_FUNCTIONS_URL` constant for production.
>   - Updates `getApiBase()` to prefer Docusaurus `functionsBaseUrl` and fall back to the production Functions URL (replacing prior window-origin and SSR `/api` fallbacks).
>   - Minor docstring updates around API base resolution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1f0cb8c4749604fdc59924f990eb75d14af9e94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API endpoint resolution with more reliable production fallback behavior, ensuring consistent connectivity across all deployment environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->