### PR TITLE
Add hardware gallery and slide to weekly report

### DIFF
--- a/apps/docs/docs/progress/2026/week-01.mdx
+++ b/apps/docs/docs/progress/2026/week-01.mdx
@@ -107,7 +107,7 @@ import {
   title="Week 1 Progress Update"
   duration={3}
   audience="Team & Stakeholders"
-  date="January 8, 2026"
+  date="January 9, 2026"
 >
 
 <SlideSection
@@ -186,6 +186,21 @@ import {
 
 <SlideSection
   number={5}
+  title="Hardware Progress"
+  duration={30}
+  icon="🔧"
+  keyPoints={[
+    "**Training drones**: Two quadcopters ready for data capture",
+    "**Hexacopter**: Large drone in development for enterprise testing",
+    "**Launcher prototype**: PVC-based net launcher for testing",
+    "**Pi 4 demo unit**: Working detection demo ready for field trials",
+  ]}
+  speakerNotes="Show the actual hardware photos - this is tangible progress."
+  script="On the hardware side, Pieter has two training quadcopters ready for capturing training footage. We have a hexacopter in development for enterprise-class detection testing. The launcher prototype uses PVC tubes with a solenoid valve, targeting 50-meter deployment range. Our Pi 4 demo unit is working and ready for field testing."
+/>
+
+<SlideSection
+  number={6}
   title="Next Priorities"
   duration={20}
   icon="📅"
@@ -199,6 +214,34 @@ import {
 />
 
 </SlideDeck>
+
+---
+
+## Hardware Gallery
+
+### Training Target Drones
+
+Two small quadcopters ready for training data capture:
+
+![Training drones - small quads](/img/training-drones.jpeg)
+
+_Left: Carbon fiber racing quad (~250mm) with prop guards. Right: Micro quad (~100mm) with orange props. Both available for capturing training footage._
+
+### Hexacopter Development
+
+Large hexacopter in development for enterprise-class detection testing:
+
+![Hexacopter in workshop](/img/hexacopter-workshop.jpeg)
+
+_Professional hexacopter (~600mm) with camera gimbal. In progress - represents larger drone class for detection model training._
+
+### Launcher Prototype
+
+PVC-based launcher prototype for net deployment testing:
+
+![Launcher prototype](/img/launcher-prototype.jpeg)
+
+_PVC tube launcher with solenoid valve. Awaiting trigger wiring and pressure testing. Target: 50m deployment range._
 
 ---
 


### PR DESCRIPTION
- Add new Hardware Progress slide (#5) to presentation deck
- Add prominent Hardware Gallery section with all three images:
  - Training drones (quadcopters for data capture)
  - Hexacopter workshop (enterprise-class testing)
  - Launcher prototype (PVC net launcher)
- Update presentation date to January 9, 2026
- Renumber Next Priorities to slide #6

### ➕ What does this PR do?
<!-- concise summary -->

### 🔨 Changes
- [ ] Feature / enhancement
- [ ] Bug fix
- [ ] Chore / refactor

### ✅ Checklist
- [ ] Tests added/updated
- [ ] Docs updated (or NA)
- [ ] No secrets in diff
- [ ] Linked to issue #____
- [ ] Screenshots / GIF added (UI changes)

### 🗒 Notes for reviewer
<!-- optional -->
