### PR TITLE
Fix marketing SWA deployment to correct domain

### DIFF
--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -44,9 +44,12 @@ on:
       resource_group:
         description: "Created resource group name"
         value: ${{ jobs.deploy-infrastructure.outputs.resource_group }}
-      static_web_app_name:
-        description: "Static Web App name"
-        value: ${{ jobs.deploy-infrastructure.outputs.static_web_app_name }}
+      static_web_app_docs_name:
+        description: "Docs Static Web App name"
+        value: ${{ jobs.deploy-infrastructure.outputs.static_web_app_docs_name }}
+      static_web_app_marketing_name:
+        description: "Marketing Static Web App name"
+        value: ${{ jobs.deploy-infrastructure.outputs.static_web_app_marketing_name }}
       functions_app_name:
         description: "Functions App name"
         value: ${{ jobs.deploy-infrastructure.outputs.functions_app_name }}
@@ -206,7 +209,8 @@ jobs:
     if: needs.validate-prerequisites.outputs.can_deploy == 'true'
     outputs:
       resource_group: ${{ steps.deploy.outputs.resource_group }}
-      static_web_app_name: ${{ steps.deploy.outputs.static_web_app_name }}
+      static_web_app_docs_name: ${{ steps.deploy.outputs.static_web_app_docs_name }}
+      static_web_app_marketing_name: ${{ steps.deploy.outputs.static_web_app_marketing_name }}
       functions_app_name: ${{ steps.deploy.outputs.functions_app_name }}
       cosmos_db_name: ${{ steps.deploy.outputs.cosmos_db_name }}
       key_vault_name: ${{ steps.deploy.outputs.key_vault_name }}
@@ -258,14 +262,21 @@ jobs:
             *) LOCATION_SHORT="${LOCATION:0:4}" ;;
           esac
 
-          # Resource names
-          RESOURCE_GROUP="${ENV_SHORT}-${LOCATION_SHORT}-rg-rooivalk"
-          KEY_VAULT_NAME="${ENV_SHORT}-${LOCATION_SHORT}-kv-rooivalk"
-          STORAGE_NAME="${ENV_SHORT}${LOCATION_SHORT}strooivalk"
-          APPI_NAME="${ENV_SHORT}-${LOCATION_SHORT}-appi-rooivalk"
-          COSMOS_NAME="${ENV_SHORT}-${LOCATION_SHORT}-cosmos-rooivalk"
-          FUNC_NAME="${ENV_SHORT}-${LOCATION_SHORT}-func-rooivalk"
-          SWA_NAME="${ENV_SHORT}-${LOCATION_SHORT}-swa-rooivalk"
+          # Resource naming convention matching Bicep: [org]-[env]-[project]-[type]-[region]
+          # org=nl (NeuralLiquid), project=rooivalk
+          ORG="nl"
+          PROJECT="rooivalk"
+          BASE_NAME="${ORG}-${ENV_SHORT}-${PROJECT}"
+
+          # Resource names (matching Bicep naming convention)
+          RESOURCE_GROUP="${BASE_NAME}-rg-${LOCATION_SHORT}"
+          KEY_VAULT_NAME="${BASE_NAME}-kv-${LOCATION_SHORT}"
+          STORAGE_NAME="${ORG}${ENV_SHORT}${PROJECT}st${LOCATION_SHORT}"
+          APPI_NAME="${BASE_NAME}-appi-${LOCATION_SHORT}"
+          COSMOS_NAME="${BASE_NAME}-cosmos-${LOCATION_SHORT}"
+          FUNC_NAME="${BASE_NAME}-func-${LOCATION_SHORT}"
+          SWA_DOCS_NAME="${BASE_NAME}-swa-${LOCATION_SHORT}"
+          SWA_MARKETING_NAME="${BASE_NAME}-marketing-swa-${LOCATION_SHORT}"
 
           # Export for later steps
           echo "environment=$ENV" >> $GITHUB_OUTPUT
@@ -276,7 +287,8 @@ jobs:
           echo "app_insights_name=$APPI_NAME" >> $GITHUB_OUTPUT
           echo "cosmos_db_name=$COSMOS_NAME" >> $GITHUB_OUTPUT
           echo "functions_app_name=$FUNC_NAME" >> $GITHUB_OUTPUT
-          echo "static_web_app_name=$SWA_NAME" >> $GITHUB_OUTPUT
+          echo "static_web_app_docs_name=$SWA_DOCS_NAME" >> $GITHUB_OUTPUT
+          echo "static_web_app_marketing_name=$SWA_MARKETING_NAME" >> $GITHUB_OUTPUT
 
       - name: Create Resource Group
         run: |
@@ -339,7 +351,8 @@ jobs:
           # Set outputs
           echo "deployment_status=success" >> $GITHUB_OUTPUT
           echo "resource_group=${{ steps.env.outputs.resource_group }}" >> $GITHUB_OUTPUT
-          echo "static_web_app_name=${{ steps.env.outputs.static_web_app_name }}" >> $GITHUB_OUTPUT
+          echo "static_web_app_docs_name=${{ steps.env.outputs.static_web_app_docs_name }}" >> $GITHUB_OUTPUT
+          echo "static_web_app_marketing_name=${{ steps.env.outputs.static_web_app_marketing_name }}" >> $GITHUB_OUTPUT
           echo "functions_app_name=${{ steps.env.outputs.functions_app_name }}" >> $GITHUB_OUTPUT
           echo "cosmos_db_name=${{ steps.env.outputs.cosmos_db_name }}" >> $GITHUB_OUTPUT
           echo "key_vault_name=${{ steps.env.outputs.key_vault_name }}" >> $GITHUB_OUTPUT
@@ -359,7 +372,8 @@ jobs:
           echo "**Resource Group**: ${{ steps.deploy.outputs.resource_group }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Resources Created:" >> $GITHUB_STEP_SUMMARY
-          echo "- **Static Web App**: ${{ steps.deploy.outputs.static_web_app_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Static Web App (Docs)**: ${{ steps.deploy.outputs.static_web_app_docs_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Static Web App (Marketing)**: ${{ steps.deploy.outputs.static_web_app_marketing_name }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Functions App**: ${{ steps.deploy.outputs.functions_app_name }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Cosmos DB**: ${{ steps.deploy.outputs.cosmos_db_name }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Key Vault**: ${{ steps.deploy.outputs.key_vault_name }}" >> $GITHUB_STEP_SUMMARY
@@ -408,14 +422,28 @@ jobs:
         run: |
           echo "Extracting deployment tokens..."
 
-          # Get Static Web Apps token
-          SWA_TOKEN=$(az staticwebapp secrets list \
-            --name "${{ needs.deploy-infrastructure.outputs.static_web_app_name }}" \
+          # Get Static Web Apps token for Docs
+          SWA_DOCS_TOKEN=$(az staticwebapp secrets list \
+            --name "${{ needs.deploy-infrastructure.outputs.static_web_app_docs_name }}" \
             --query "properties.apiKey" -o tsv 2>/dev/null || echo "")
 
-          if [ -z "$SWA_TOKEN" ]; then
-            echo "::warning::Could not retrieve Static Web Apps token. It may still be provisioning."
-            SWA_TOKEN="PROVISIONING"
+          if [ -z "$SWA_DOCS_TOKEN" ]; then
+            echo "::warning::Could not retrieve Docs Static Web Apps token. It may still be provisioning."
+            SWA_DOCS_TOKEN="PROVISIONING"
+          else
+            echo "✅ Retrieved Docs SWA token"
+          fi
+
+          # Get Static Web Apps token for Marketing
+          SWA_MARKETING_TOKEN=$(az staticwebapp secrets list \
+            --name "${{ needs.deploy-infrastructure.outputs.static_web_app_marketing_name }}" \
+            --query "properties.apiKey" -o tsv 2>/dev/null || echo "")
+
+          if [ -z "$SWA_MARKETING_TOKEN" ]; then
+            echo "::warning::Could not retrieve Marketing Static Web Apps token. It may still be provisioning."
+            SWA_MARKETING_TOKEN="PROVISIONING"
+          else
+            echo "✅ Retrieved Marketing SWA token"
           fi
 
           # Get Function App publish profile
@@ -443,12 +471,14 @@ jobs:
             --query connectionString -o tsv 2>/dev/null || echo "")
 
           # Save to outputs (masked)
-          echo "::add-mask::$SWA_TOKEN"
+          echo "::add-mask::$SWA_DOCS_TOKEN"
+          echo "::add-mask::$SWA_MARKETING_TOKEN"
           echo "::add-mask::$FUNC_PROFILE"
           echo "::add-mask::$COSMOS_CONN"
           echo "::add-mask::$APP_INSIGHTS_CONN"
 
-          echo "swa_token=$SWA_TOKEN" >> $GITHUB_OUTPUT
+          echo "swa_docs_token=$SWA_DOCS_TOKEN" >> $GITHUB_OUTPUT
+          echo "swa_marketing_token=$SWA_MARKETING_TOKEN" >> $GITHUB_OUTPUT
           echo "func_profile=$FUNC_PROFILE" >> $GITHUB_OUTPUT
           echo "cosmos_connection=$COSMOS_CONN" >> $GITHUB_OUTPUT
           echo "app_insights_connection=$APP_INSIGHTS_CONN" >> $GITHUB_OUTPUT
@@ -459,11 +489,15 @@ jobs:
         run: |
           echo "Configuring GitHub secrets..."
 
-          # Set secrets
-          if [ "${{ steps.tokens.outputs.swa_token }}" != "PROVISIONING" ]; then
-            echo "${{ steps.tokens.outputs.swa_token }}" | gh secret set AZURE_STATIC_WEB_APPS_API_TOKEN
-            echo "${{ steps.tokens.outputs.swa_token }}" | gh secret set AZURE_STATIC_WEB_APPS_MARKETING_API_TOKEN
-            echo "✅ Set Static Web Apps deployment tokens"
+          # Set SWA tokens for each app
+          if [ "${{ steps.tokens.outputs.swa_docs_token }}" != "PROVISIONING" ]; then
+            echo "${{ steps.tokens.outputs.swa_docs_token }}" | gh secret set AZURE_STATIC_WEB_APPS_API_TOKEN
+            echo "✅ Set Docs Static Web Apps deployment token"
+          fi
+
+          if [ "${{ steps.tokens.outputs.swa_marketing_token }}" != "PROVISIONING" ]; then
+            echo "${{ steps.tokens.outputs.swa_marketing_token }}" | gh secret set AZURE_STATIC_WEB_APPS_MARKETING_API_TOKEN
+            echo "✅ Set Marketing Static Web Apps deployment token"
           fi
 
           if [ "${{ steps.tokens.outputs.func_profile }}" != "PROVISIONING" ]; then
@@ -498,8 +532,8 @@ jobs:
           echo "The following secrets and variables have been configured:" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Secrets:" >> $GITHUB_STEP_SUMMARY
-          echo "- AZURE_STATIC_WEB_APPS_API_TOKEN" >> $GITHUB_STEP_SUMMARY
-          echo "- AZURE_STATIC_WEB_APPS_MARKETING_API_TOKEN" >> $GITHUB_STEP_SUMMARY
+          echo "- AZURE_STATIC_WEB_APPS_API_TOKEN (Docs SWA)" >> $GITHUB_STEP_SUMMARY
+          echo "- AZURE_STATIC_WEB_APPS_MARKETING_API_TOKEN (Marketing SWA)" >> $GITHUB_STEP_SUMMARY
           echo "- AZURE_FUNCTIONS_PUBLISH_PROFILE" >> $GITHUB_STEP_SUMMARY
           echo "- COSMOS_DB_CONNECTION_STRING" >> $GITHUB_STEP_SUMMARY
           echo "- APPLICATIONINSIGHTS_CONNECTION_STRING" >> $GITHUB_STEP_SUMMARY
@@ -536,9 +570,14 @@ jobs:
           echo "### 1. Extract Deployment Tokens" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
-          echo "# Static Web Apps token" >> $GITHUB_STEP_SUMMARY
+          echo "# Static Web Apps token (Docs)" >> $GITHUB_STEP_SUMMARY
           echo "az staticwebapp secrets list \\" >> $GITHUB_STEP_SUMMARY
-          echo "  --name ${{ needs.deploy-infrastructure.outputs.static_web_app_name }} \\" >> $GITHUB_STEP_SUMMARY
+          echo "  --name ${{ needs.deploy-infrastructure.outputs.static_web_app_docs_name }} \\" >> $GITHUB_STEP_SUMMARY
+          echo "  --query 'properties.apiKey' -o tsv" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "# Static Web Apps token (Marketing)" >> $GITHUB_STEP_SUMMARY
+          echo "az staticwebapp secrets list \\" >> $GITHUB_STEP_SUMMARY
+          echo "  --name ${{ needs.deploy-infrastructure.outputs.static_web_app_marketing_name }} \\" >> $GITHUB_STEP_SUMMARY
           echo "  --query 'properties.apiKey' -o tsv" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "# Function App publish profile" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
- Update workflow naming to match Bicep convention: [org]-[env]-[project]-[type]-[region] (e.g., nl-dev-rooivalk-swa-eus2)
- Add separate SWA resources for docs and marketing:
  - static_web_app_docs_name for docs site
  - static_web_app_marketing_name for marketing site
- Extract and set separate deployment tokens for each SWA
- Update all job outputs and workflow_call outputs
- Update manual secrets instructions to show both SWAs

This fixes the issue where both SWAs were using the same deployment token, causing marketing to deploy to the docs SWA domain.

### ➕ What does this PR do?
<!-- concise summary -->

### 🔨 Changes
- [ ] Feature / enhancement
- [ ] Bug fix
- [ ] Chore / refactor

### ✅ Checklist
- [ ] Tests added/updated
- [ ] Docs updated (or NA)
- [ ] No secrets in diff
- [ ] Linked to issue #____
- [ ] Screenshots / GIF added (UI changes)

### 🗒 Notes for reviewer
<!-- optional -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored deployment workflow to manage documentation and marketing applications as separate services with distinct deployment tokens and configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->