### PR TITLE
Fix resource group naming to use existing pattern

### DIFF
--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -262,14 +262,18 @@ jobs:
             *) LOCATION_SHORT="${LOCATION:0:4}" ;;
           esac
 
-          # Resource naming convention matching Bicep: [org]-[env]-[project]-[type]-[region]
+          # Resource naming - use existing resource group, Bicep handles internal resource naming
           # org=nl (NeuralLiquid), project=rooivalk
           ORG="nl"
           PROJECT="rooivalk"
+
+          # Resource group uses existing pattern to avoid conflicts with existing resources
+          RESOURCE_GROUP="${ENV_SHORT}-${LOCATION_SHORT}-rg-rooivalk"
+
+          # Bicep naming convention: [org]-[env]-[project]-[type]-[region]
           BASE_NAME="${ORG}-${ENV_SHORT}-${PROJECT}"
 
-          # Resource names (matching Bicep naming convention)
-          RESOURCE_GROUP="${BASE_NAME}-rg-${LOCATION_SHORT}"
+          # Resource names (matching Bicep naming convention in main.bicep)
           KEY_VAULT_NAME="${BASE_NAME}-kv-${LOCATION_SHORT}"
           STORAGE_NAME="${ORG}${ENV_SHORT}${PROJECT}st${LOCATION_SHORT}"
           APPI_NAME="${BASE_NAME}-appi-${LOCATION_SHORT}"


### PR DESCRIPTION
Keep existing resource group naming pattern (dev-eus2-rg-rooivalk) to avoid conflicts with existing resources. The storage account nldevrooivalksteus2 already exists in the original resource group.

This preserves the fix for separate SWA tokens while avoiding the StorageAccountInAnotherResourceGroup deployment error.

### ➕ What does this PR do?
<!-- concise summary -->

### 🔨 Changes
- [ ] Feature / enhancement
- [ ] Bug fix
- [ ] Chore / refactor

### ✅ Checklist
- [ ] Tests added/updated
- [ ] Docs updated (or NA)
- [ ] No secrets in diff
- [ ] Linked to issue #____
- [ ] Screenshots / GIF added (UI changes)

### 🗒 Notes for reviewer
<!-- optional -->
