### PR TITLE
Fix marketing deploy to run on manual workflow_dispatch

### DIFF
--- a/.github/workflows/deploy-marketing-azure.yml
+++ b/.github/workflows/deploy-marketing-azure.yml
@@ -77,8 +77,8 @@ jobs:
   build-and-deploy:
     needs: check-secrets
     if:
-      github.event_name == 'push' || (github.event_name == 'pull_request' &&
-      github.event.action != 'closed')
+      github.event_name == 'workflow_dispatch' || github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     name: Build and Deploy
     permissions:


### PR DESCRIPTION
The build-and-deploy job condition was missing workflow_dispatch, causing manual triggers to skip the deployment step entirely.

### ➕ What does this PR do?
<!-- concise summary -->

### 🔨 Changes
- [ ] Feature / enhancement
- [ ] Bug fix
- [ ] Chore / refactor

### ✅ Checklist
- [ ] Tests added/updated
- [ ] Docs updated (or NA)
- [ ] No secrets in diff
- [ ] Linked to issue #____
- [ ] Screenshots / GIF added (UI changes)

### 🗒 Notes for reviewer
<!-- optional -->
