### PR TITLE
chore: update Rust dependencies and generated schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6666,6 +6666,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "libc",
  "phoenix-common",
  "phoenix-evidence",
  "serde",

--- a/apps/threat-simulator-desktop/src-tauri/gen/schemas/windows-schema.json
+++ b/apps/threat-simulator-desktop/src-tauri/gen/schemas/windows-schema.json
@@ -393,10 +393,10 @@
           "markdownDescription": "Default core plugins set.\n#### This default permission set includes:\n\n- `core:path:default`\n- `core:event:default`\n- `core:window:default`\n- `core:webview:default`\n- `core:app:default`\n- `core:image:default`\n- `core:resources:default`\n- `core:menu:default`\n- `core:tray:default`"
         },
         {
-          "description": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-version`\n- `allow-name`\n- `allow-tauri-version`\n- `allow-identifier`\n- `allow-bundle-type`",
+          "description": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-version`\n- `allow-name`\n- `allow-tauri-version`\n- `allow-identifier`\n- `allow-bundle-type`\n- `allow-register-listener`\n- `allow-remove-listener`",
           "type": "string",
           "const": "core:app:default",
-          "markdownDescription": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-version`\n- `allow-name`\n- `allow-tauri-version`\n- `allow-identifier`\n- `allow-bundle-type`"
+          "markdownDescription": "Default permissions for the plugin.\n#### This default permission set includes:\n\n- `allow-version`\n- `allow-name`\n- `allow-tauri-version`\n- `allow-identifier`\n- `allow-bundle-type`\n- `allow-register-listener`\n- `allow-remove-listener`"
         },
         {
           "description": "Enables the app_hide command without any pre-configured scope.",
@@ -441,10 +441,22 @@
           "markdownDescription": "Enables the name command without any pre-configured scope."
         },
         {
+          "description": "Enables the register_listener command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-register-listener",
+          "markdownDescription": "Enables the register_listener command without any pre-configured scope."
+        },
+        {
           "description": "Enables the remove_data_store command without any pre-configured scope.",
           "type": "string",
           "const": "core:app:allow-remove-data-store",
           "markdownDescription": "Enables the remove_data_store command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the remove_listener command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:allow-remove-listener",
+          "markdownDescription": "Enables the remove_listener command without any pre-configured scope."
         },
         {
           "description": "Enables the set_app_theme command without any pre-configured scope.",
@@ -513,10 +525,22 @@
           "markdownDescription": "Denies the name command without any pre-configured scope."
         },
         {
+          "description": "Denies the register_listener command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-register-listener",
+          "markdownDescription": "Denies the register_listener command without any pre-configured scope."
+        },
+        {
           "description": "Denies the remove_data_store command without any pre-configured scope.",
           "type": "string",
           "const": "core:app:deny-remove-data-store",
           "markdownDescription": "Denies the remove_data_store command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the remove_listener command without any pre-configured scope.",
+          "type": "string",
+          "const": "core:app:deny-remove-listener",
+          "markdownDescription": "Denies the remove_listener command without any pre-configured scope."
         },
         {
           "description": "Denies the set_app_theme command without any pre-configured scope.",


### PR DESCRIPTION
## Summary
Updates Rust dependencies and auto-generated Tauri schema files.

## Changes
- **Cargo.lock**: Added \libc\ dependency for threat-simulator-desktop
- **windows-schema.json**: Updated auto-generated schema with additional permission descriptions (\llow-register-listener\, \llow-remove-listener\)

## Notes
- Cargo.lock update from dependency changes
- Schema file auto-generated by Tauri
- No functional changes to code