### PR TITLE
Update environment variable naming in TEST_PLAN

### DIFF
--- a/apps/detector/tests/TEST_PLAN.md
+++ b/apps/detector/tests/TEST_PLAN.md
@@ -47,7 +47,7 @@
 **Test Areas:**
 
 1. **Environment Variable Loading**
-   - Test env prefix handling (CAPTURE*, INFERENCE*, etc.)
+   - Test env prefix handling (CAPTURE_*, INFERENCE_*, etc.)
    - Test nested delimiter handling (\_\_)
    - Test .env file loading
 


### PR DESCRIPTION
Update CAPTURE* and INFERENCE* to CAPTURE_* and INFERENCE_* to clarify these are prefix patterns with underscores, not literal env var names.

### ➕ What does this PR do?
<!-- concise summary -->

### 🔨 Changes
- [ ] Feature / enhancement
- [ ] Bug fix
- [ ] Chore / refactor

### ✅ Checklist
- [ ] Tests added/updated
- [ ] Docs updated (or NA)
- [ ] No secrets in diff
- [ ] Linked to issue #____
- [ ] Screenshots / GIF added (UI changes)

### 🗒 Notes for reviewer
<!-- optional -->
