### PR TITLE
🔒 [security fix] Mitigate XSS in JSON-LD script blocks

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -18,6 +18,7 @@
     "test:coverage": "jest --coverage"
   },
   "dependencies": {
+    "@phoenix-rooivalk/utils": "workspace:*",
     "@azure/cosmos": "^4.9.0",
     "@azure/msal-browser": "^5.2.0",
     "@docusaurus/core": "^3.9.2",

--- a/apps/docs/src/components/SEO/ArticleMeta.tsx
+++ b/apps/docs/src/components/SEO/ArticleMeta.tsx
@@ -7,6 +7,7 @@
 
 import React from "react";
 import Head from "@docusaurus/Head";
+import { serializeJsonLd } from "@phoenix-rooivalk/utils";
 
 export interface ArticleMetaProps {
   title: string;
@@ -148,9 +149,10 @@ export function ArticleStructuredData({
 
   return (
     <Head>
-      <script type="application/ld+json">
-        {JSON.stringify(structuredData)}
-      </script>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(structuredData) }}
+      />
     </Head>
   );
 }

--- a/apps/marketing/src/__tests__/jsonLd.test.ts
+++ b/apps/marketing/src/__tests__/jsonLd.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { serializeJsonLd } from "@phoenix-rooivalk/utils";
+
+describe("serializeJsonLd", () => {
+  it("should stringify a simple object", () => {
+    const data = { key: "value" };
+    expect(serializeJsonLd(data)).toBe('{"key":"value"}');
+  });
+
+  it("should escape < and > characters to prevent </script> breakout", () => {
+    const data = {
+      description: "This is a </script><script>alert('XSS')</script> test",
+    };
+    const result = serializeJsonLd(data);
+    expect(result).not.toContain("</script>");
+    expect(result).not.toContain("<script>");
+    expect(result).toContain("\\u003c/script\\u003e");
+    expect(result).toContain("\\u003cscript\\u003e");
+    expect(result).toBe(
+      '{"description":"This is a \\u003c/script\\u003e\\u003cscript\\u003ealert(\'XSS\')\\u003c/script\\u003e test"}'
+    );
+  });
+
+  it("should handle nested objects", () => {
+    const data = {
+      "@context": "https://schema.org",
+      mainEntity: [
+        {
+          name: "<b>Question</b>",
+        },
+      ],
+    };
+    const result = serializeJsonLd(data);
+    expect(result).toContain("\\u003cb\\u003eQuestion\\u003c/b\\u003e");
+  });
+
+  it("should return empty object string for non-serializable data", () => {
+    // JSON.stringify returns undefined for functions
+    expect(serializeJsonLd(() => {})).toBe("{}");
+  });
+});

--- a/apps/marketing/src/app/home.tsx
+++ b/apps/marketing/src/app/home.tsx
@@ -8,6 +8,8 @@ import { FeaturesSection } from "../components/sections/FeaturesSection";
 import { HeroSection } from "../components/sections/HeroSection";
 import { ProductHighlightsSection } from "../components/sections/ProductHighlightsSection";
 import { InteractiveMesh } from "../components/ui/InteractiveMesh";
+import { serializeJsonLd } from "@phoenix-rooivalk/utils";
+
 import { usePerformanceOptimizations } from "../hooks/usePerformanceOptimizations";
 import styles from "./home.module.css";
 
@@ -43,7 +45,7 @@ export default function HomePage(): React.ReactElement {
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{
-          __html: JSON.stringify({
+          __html: serializeJsonLd({
             "@context": "https://schema.org",
             "@type": "FAQPage",
             mainEntity: [

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,2 +1,3 @@
 export { downloadWhitepaper } from "./downloadWhitepaper";
 export { formatCurrency } from "./formatter";
+export { serializeJsonLd } from "./jsonLd";

--- a/packages/utils/src/jsonLd.ts
+++ b/packages/utils/src/jsonLd.ts
@@ -1,0 +1,18 @@
+/**
+ * Safely serializes an object to a JSON string for use in JSON-LD script blocks.
+ * Escapes characters that could be used to break out of a <script> tag.
+ *
+ * @param data The object to serialize
+ * @returns A safely escaped JSON string, or an empty object string if serialization fails
+ */
+export function serializeJsonLd(data: unknown): string {
+  const json = JSON.stringify(data);
+
+  if (json === undefined) {
+    return "{}";
+  }
+
+  // Escape '<' and '>' to prevent </script> tags from ending the script block early
+  // and other characters that might be problematic in some contexts.
+  return json.replace(/</g, "\\u003c").replace(/>/g, "\\u003e");
+}


### PR DESCRIPTION
🎯 **What:** Fixed potential XSS vulnerabilities in `<script type="application/ld+json">` blocks by replacing raw `JSON.stringify` with a safe `serializeJsonLd` utility.

⚠️ **Risk:** If dynamic data (even if ostensibly safe) is introduced into these blocks in the future, it could contain `</script>` which would prematurely end the script block and allow for malicious script injection.

🛡️ **Solution:** 
- Introduced a new utility `serializeJsonLd` in the `@phoenix-rooivalk/utils` package. This utility stringifies the data and escapes `<` to `\u003c` and `>` to `\u003e`.
- Updated `apps/marketing/src/app/home.tsx` to use this utility.
- Updated `apps/docs/src/components/SEO/ArticleMeta.tsx` to use this utility and correctly use `dangerouslySetInnerHTML` for the script content.
- Added workspace dependency on `@phoenix-rooivalk/utils` to both applications.
- Added unit tests to verify the escaping logic and handle edge cases like non-serializable data.

---
*PR created automatically by Jules for task [16090738631007891339](https://jules.google.com/task/16090738631007891339) started by @JustAGhosT*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a shared JSON-LD serialization utility used across the application that safely escapes special characters to prevent script injection vulnerabilities in structured data.

* **Tests**
  * Added comprehensive test coverage for JSON-LD serialization, validating simple objects, nested data structures, character escaping prevention, and proper handling of non-serializable data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->