### PR TITLE
chore(ci): reduce CodeQL to weekly + manual only

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,24 +1,8 @@
 name: "CodeQL Security Analysis"
 
 on:
-  push:
-    branches: ["main"]
-    paths:
-      - "**/*.ts"
-      - "**/*.tsx"
-      - "**/*.js"
-      - "**/*.jsx"
-      - "**/*.rs"
-      - ".github/workflows/codeql.yml"
-  pull_request:
-    branches: ["main"]
-    paths:
-      - "**/*.ts"
-      - "**/*.tsx"
-      - "**/*.js"
-      - "**/*.jsx"
-      - "**/*.rs"
-      - ".github/workflows/codeql.yml"
+  # Reduced to weekly + manual to cut GitHub Actions costs
+  # Was running on every push/PR including Renovate bot
   schedule:
     - cron: "30 2 * * 1" # Weekly on Monday at 2:30 AM UTC
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- Removes `push` and `pull_request` triggers from CodeQL workflow
- Keeps weekly schedule (Mon 2:30am UTC) and manual `workflow_dispatch`
- Reduces GitHub Actions costs from bot PRs triggering expensive scans

🤖 Generated with [Claude Code](https://claude.com/claude-code)