### PR TITLE
Add Drone Net Launcher documentation and update Phase 1 BOM

### DIFF
--- a/apps/docs/docs/technical/hardware/phase1/drone-net-launcher.md
+++ b/apps/docs/docs/technical/hardware/phase1/drone-net-launcher.md
@@ -1,0 +1,382 @@
+---
+id: phase1-drone-net-launcher
+title: "Drone Net Launcher — Air-to-Air Intercept Node"
+sidebar_label: Drone Net Launcher
+sidebar_position: 6
+description:
+  Phase 1A build guide for a drone-mounted ESP32-C3 net launcher node. Receives
+  arm/fire commands from the ground station over WiFi. Spring-loaded deployment
+  with servo pin release. Human-in-the-loop only.
+difficulty: intermediate
+estimated_reading_time: 8
+points: 15
+tags:
+  - hardware
+  - phase-1
+  - esp32
+  - drone
+  - net-launcher
+  - actuation
+  - safety
+  - air-to-air
+phase: ["seed"]
+prerequisites: ["phase1-hardware-overview", "phase1-trigger-node"]
+---
+
+# Drone Net Launcher — Air-to-Air Intercept Node
+
+A drone-mounted ESP32-C3 node that receives arm/fire commands from the ground
+station and deploys a lightweight capture net via spring-loaded release. **Single
+shot, human-in-the-loop only.**
+
+---
+
+## What It Proves
+
+> **Ground command → Airborne actuation → Net deployment**, extending the
+> detect-decide-act chain into the air domain.
+
+The ground station (Turret Tracker + SkyWatch) identifies and tracks a target
+drone. The operator arms the intercept drone, maneuvers it into position, and
+commands fire. The net deploys — proving the full air-to-air engagement loop
+without any autonomous firing.
+
+---
+
+## Why ESP32-C3
+
+| Factor          | ESP32-C3                          | ESP32-S (30-pin)        |
+| --------------- | --------------------------------- | ----------------------- |
+| Weight          | ~5g (bare module)                 | ~10-15g                 |
+| Core            | RISC-V single-core (160MHz)      | Xtensa dual-core        |
+| WiFi            | 802.11 b/g/n                     | Same                    |
+| BLE             | 5.0 (backup comms)               | 4.2                     |
+| GPIO            | 15 usable — plenty for 1 servo   | 25+ usable              |
+| Power draw      | ~80mA active WiFi                | ~160mA active WiFi      |
+| Cost            | ~$3-4                            | ~$5-8                   |
+| **Verdict**     | **Best for drone (light, low power)** | Better for ground station |
+
+Every gram matters on a drone. The C3's lower weight and power draw make it the
+right choice for an airborne node.
+
+---
+
+## Bill of Materials — Drone Node
+
+| Component        | Part                            | Specification                          | Est. Cost |
+| ---------------- | ------------------------------- | -------------------------------------- | --------- |
+| Compute          | ESP32-C3 SuperMini              | RISC-V, WiFi + BLE 5.0                | $3–4      |
+| Trigger servo    | SG90 micro servo                | Pin-pull release mechanism             | $2        |
+| Power regulator  | Mini buck (MP2307 or AMS1117)   | Drone battery voltage → 3.3V          | $1–2      |
+| Arm switch       | Micro toggle (SPST)             | Physical master arm on drone frame     | $0.50     |
+| Status LED       | 3mm red/green                   | Armed/safe visible from ground         | $0.50     |
+| Net assembly     | Lightweight mesh net            | ~1m², nylon or polyester, corner weights | $5       |
+| Corner weights   | Fishing sinkers or steel nuts   | 4× ~10-15g each                        | $2        |
+| Spring mechanism | Compression spring or bungee    | Deployment force for net ejection      | $2–3      |
+| Release housing  | 3D-printed or lightweight tube  | Holds net + spring, servo-latched lid  | $2–5      |
+| Wiring           | Silicone wire (26AWG), JST-XH   | Lightweight, flexible                  | $2        |
+| **Total**        |                                 |                                        | **$20–30**|
+
+### Weight Budget
+
+| Component          | Weight   |
+| ------------------ | -------- |
+| ESP32-C3 module    | 5g       |
+| SG90 servo         | 9g       |
+| Buck converter     | 3g       |
+| Wiring + switch    | 5g       |
+| Net (1m² nylon)    | 20-30g   |
+| Corner weights     | 40-60g   |
+| Spring + housing   | 30-50g   |
+| **Total payload**  | **~112-162g** |
+
+Most consumer drones (250mm+) can carry 150-300g payload. A 250mm racing quad
+can handle the lower end; a 450mm+ platform handles it comfortably.
+
+---
+
+## Architecture
+
+```text
+  ┌──────────────────────────────────────────────────────────────┐
+  │                  Drone Net Launcher Node                      │
+  │                                                              │
+  │   Drone Battery ── Mini Buck ── 3.3V ── ESP32-C3             │
+  │                                          │                    │
+  │                                   GPIO ── Micro toggle (arm)  │
+  │                                   GPIO ── Green LED (armed)   │
+  │                                   GPIO ── Red LED (safe)      │
+  │                                   GPIO ── SG90 signal         │
+  │                                                              │
+  │                    ┌──────────────────────────┐              │
+  │                    │   Net Canister            │              │
+  │                    │                          │              │
+  │                    │   ┌── Spring ──┐         │              │
+  │                    │   │   Net      │         │              │
+  │                    │   │  (folded)  │         │              │
+  │                    │   └────────────┘         │              │
+  │                    │        ▲                  │              │
+  │                    │   Servo pin (latch)       │              │
+  │                    └──────────────────────────┘              │
+  │                                                              │
+  │   WiFi ◄── ARM / FIRE commands from ground station           │
+  └──────────────────────────────────────────────────────────────┘
+
+  Ground Station (ESP32-S)                    Drone (ESP32-C3)
+  ┌───────────────────┐    WiFi (2.4GHz)    ┌───────────────────┐
+  │ SkyWatch detect   │ ─────────────────── │ Net Launcher      │
+  │ Turret track      │    ARM / FIRE cmd   │ Servo release     │
+  │ Operator console  │ ◄───────────────── │ Status heartbeat  │
+  └───────────────────┘    Status / ACK     └───────────────────┘
+```
+
+---
+
+## Deployment Mechanism — Spring-Loaded Pin Release
+
+The simplest reliable mechanism for a first prototype:
+
+1. **Net is folded** into a lightweight canister (3D-printed tube or PVC cap).
+2. **Compression spring** sits beneath the folded net.
+3. **Servo arm holds a retaining pin** that keeps the spring compressed.
+4. On `FIRE` command: servo rotates → pin withdraws → spring pushes net out →
+   corner weights spread the net in flight.
+
+### Why Spring + Servo (Not Solenoid or CO2)
+
+| Mechanism      | Weight | Reliability | Complexity | Drone-suitable |
+| -------------- | ------ | ----------- | ---------- | -------------- |
+| **Spring + servo** | Low | High       | Low        | **Yes**        |
+| CO2 cartridge  | Medium | Medium      | Medium     | Marginal       |
+| Solenoid       | Medium | High        | Medium     | Marginal       |
+| Pyrotechnic    | Low    | High        | High       | No (regulatory)|
+
+Spring + servo wins: no consumables, no high-current draw, no regulatory issues,
+reloadable.
+
+---
+
+## Safety Architecture
+
+The drone node inherits and extends the Trigger Node safety model. Airborne
+actuation demands **stricter** safety than ground-based:
+
+### Safety Chain (All Must Pass)
+
+1. **Physical arm switch** — micro toggle on the drone frame. Must be set before
+   takeoff. Pilot physically confirms arming.
+2. **Software arm state** — firmware mirrors physical switch. Cannot be armed by
+   software alone.
+3. **Ground station ARM command** — two-stage: ground sends `ARM`, drone ACKs.
+   Separate `FIRE` command required afterward.
+4. **Pre-shared token auth** — `Authorization: Bearer <token>` on all commands.
+5. **Heartbeat watchdog** — drone expects heartbeat from ground station every
+   500ms. If 3 consecutive heartbeats are missed (1.5s), the node reverts to
+   **SAFE** state. Loss of comms = safe, not fire.
+6. **Single-shot lockout** — once fired, the node enters SPENT state. Cannot
+   re-arm without physical reload and power cycle.
+7. **Altitude/orientation guard** (Phase 1B) — future: IMU checks that drone is
+   in a reasonable flight attitude before allowing fire.
+
+### State Machine
+
+```text
+  POWER ON
+     │
+     ▼
+  ┌──────┐   physical switch ON    ┌────────┐
+  │ SAFE │ ───────────────────────▶│ ARMED  │
+  │      │◀─────────────────────── │(local) │
+  └──────┘   switch OFF / timeout  └────┬───┘
+                                        │ ground ARM cmd + token
+                                        ▼
+                                   ┌─────────┐
+                                   │ ARMED   │
+                                   │(remote) │
+                                   └────┬────┘
+                                        │ ground FIRE cmd + token
+                                        ▼
+                                   ┌─────────┐
+                                   │ FIRING  │ ── servo release (200ms pulse)
+                                   └────┬────┘
+                                        │
+                                        ▼
+                                   ┌─────────┐
+                                   │  SPENT  │ ── lockout until reload + reboot
+                                   └─────────┘
+
+  Any state ──(heartbeat timeout)──▶ SAFE
+  Any state ──(physical switch OFF)──▶ SAFE
+```
+
+---
+
+## Communication Protocol
+
+### Ground → Drone
+
+| Endpoint      | Method | Purpose                        | Auth Required |
+| ------------- | ------ | ------------------------------ | ------------- |
+| `POST /arm`   | POST   | Transition to ARMED (remote)   | Bearer token  |
+| `POST /fire`  | POST   | Deploy net                     | Bearer token  |
+| `POST /safe`  | POST   | Force return to SAFE           | Bearer token  |
+| `GET /status` | GET    | Query current state            | Bearer token  |
+
+### Drone → Ground
+
+| Message     | Interval | Content                              |
+| ----------- | -------- | ------------------------------------ |
+| Heartbeat   | 200ms    | `{ state, battery_v, uptime_ms }`    |
+| ACK         | On event | `{ cmd, result, timestamp }`         |
+| FIRED       | Once     | `{ timestamp, state: "spent" }`      |
+
+### Example Flow
+
+```text
+Ground                              Drone
+  │                                   │
+  │──── POST /arm (token) ──────────▶│
+  │◀─── 200 { state: "armed" } ─────│
+  │                                   │
+  │   ... operator maneuvers drone ... │
+  │                                   │
+  │──── POST /fire (token) ─────────▶│
+  │◀─── 200 { state: "firing" } ────│
+  │                                   │ ── servo actuates
+  │◀─── FIRED { state: "spent" } ───│
+  │                                   │
+```
+
+---
+
+## Build Steps
+
+### Step 1 — Power
+
+1. Identify drone battery voltage (typically 3S LiPo = 11.1V nominal).
+2. Connect mini buck converter input to drone battery pads or XT30 pigtail.
+3. Adjust output to 3.3V (ESP32-C3 is 3.3V native — no 5V needed).
+4. Verify voltage under load before connecting the C3.
+
+### Step 2 — ESP32-C3 Setup
+
+1. Flash with Arduino IDE or ESP-IDF (C3 uses RISC-V toolchain).
+2. Configure WiFi credentials (hardcoded for demo, move to BLE provisioning in
+   Phase 1B).
+3. Set up HTTP server with `/arm`, `/fire`, `/safe`, `/status` endpoints.
+4. Implement heartbeat broadcast (UDP or HTTP POST to ground station IP).
+
+### Step 3 — Arm/Disarm Circuit
+
+1. Wire micro toggle between GPIO pin and GND (enable internal pull-up).
+2. Wire green LED (+ 220Ω resistor) to armed GPIO.
+3. Wire red LED (+ 220Ω resistor) to safe GPIO.
+4. Firmware reads switch on boot and on interrupt — physical switch always wins.
+
+### Step 4 — Servo Trigger
+
+1. SG90 signal wire → ESP32-C3 GPIO (e.g., GPIO 4).
+2. SG90 power → 3.3V rail (SG90 operates 4.8-6V but will work at reduced torque
+   for a pin pull; alternatively tap 5V from a separate regulator).
+3. Neutral position: servo arm holds retaining pin in place.
+4. Fire position: servo rotates 90° → pin withdraws → spring releases.
+5. After fire: servo returns to neutral, but node enters SPENT state regardless.
+
+### Step 5 — Net Canister Assembly
+
+1. **Canister**: lightweight tube (PVC cap, 3D print, or cardboard for
+   prototype). ~50mm diameter, ~80mm tall.
+2. **Spring**: compression spring at the bottom, 20-30mm travel, moderate force.
+3. **Net folding**: fold net accordion-style with corner weights on the outside.
+4. **Retaining pin**: wire or thin dowel through canister wall, held by servo
+   arm.
+5. **Mounting**: zip-tie or velcro-strap canister to drone undercarriage,
+   pointing downward.
+
+### Step 6 — Integration Test
+
+1. **Bench test (no propellers)**: power drone electronics, test full ARM → FIRE
+   sequence. Verify servo actuates, net ejects.
+2. **Heartbeat test**: disconnect ground station WiFi → verify drone reverts to
+   SAFE within 1.5s.
+3. **Auth test**: send FIRE without token → verify 403 rejection.
+4. **Lockout test**: after firing, attempt re-arm → verify refusal.
+5. **Hover test**: arm drone (propellers on, tethered or low hover), fire net
+   into open area.
+
+---
+
+## Acceptance Criteria
+
+- [ ] ESP32-C3 connects to ground station WiFi and sends heartbeats
+- [ ] Physical arm switch must be ON before any remote arming
+- [ ] Two-stage arm: ground ARM command required before FIRE is accepted
+- [ ] Bearer token authentication on all command endpoints
+- [ ] Heartbeat watchdog reverts to SAFE on comms loss (≤1.5s)
+- [ ] Servo actuates on FIRE, deploying the net from the canister
+- [ ] Single-shot lockout: SPENT state after firing, no re-arm without reload
+- [ ] All commands and state transitions are logged with timestamps
+- [ ] Total payload weight ≤ 200g (including net and housing)
+- [ ] Net deploys and spreads to ≥ 0.5m² in bench drop test
+
+---
+
+## Node Assignment Summary
+
+With the drone net launcher, the Phase 1 ESP32 fleet becomes:
+
+| Node               | Board        | Location       | Role                        |
+| ------------------ | ------------ | -------------- | --------------------------- |
+| Turret Tracker     | ESP32-S (30) | Ground station | Pan/tilt camera tracking    |
+| Trigger Node       | ESP32-DevKitC| Ground station | Safe actuation demo (LED)   |
+| **Drone Launcher** | **ESP32-C3** | **On drone**   | **Net deployment trigger**  |
+| 38-pin expansion   | ESP32 (38)   | Ground station | Sensor breakout (Phase 1B)  |
+
+---
+
+## Drone Platform Requirements
+
+The host drone must meet these minimums:
+
+| Requirement        | Minimum                         | Recommended              |
+| ------------------ | ------------------------------- | ------------------------ |
+| Frame size         | 250mm (racing quad)             | 450mm+ (payload quad)    |
+| Payload capacity   | 150g                            | 300g+                    |
+| Flight time (loaded)| 3-5 min                        | 8-12 min                 |
+| Battery            | 3S 1500mAh LiPo                | 4S 2200mAh+ LiPo        |
+| FC firmware        | Any (Betaflight, ArduPilot, iNav) | ArduPilot (waypoint support) |
+| Mounting points    | Zip-tie to frame                | Dedicated payload rail   |
+
+:::caution
+The net launcher is **additional payload** on the drone. Always verify your
+drone's thrust-to-weight ratio remains above 2:1 after mounting the launcher.
+Below 2:1 the drone becomes sluggish and difficult to maneuver for intercept.
+:::
+
+---
+
+## Leave for Later (Intentionally)
+
+| Item                                    | Why                                          |
+| --------------------------------------- | -------------------------------------------- |
+| Autonomous fire (no human command)      | Phase 1 is human-in-the-loop only            |
+| IMU-based attitude guard                | Requires accelerometer integration (Phase 1B)|
+| Multi-shot / reload mechanism           | Single-shot proves the concept               |
+| GPS-based engagement envelope           | Phase 2 with ArduPilot integration           |
+| Encrypted comms (TLS/DTLS)             | Phase 1B; PSK token is sufficient for demo   |
+| FPV camera feed integration             | Separate system; not part of launcher node   |
+| Automated lead calculation              | Phase 2; operator eyeballs it for now        |
+
+---
+
+## Upgrade Path
+
+| From (Phase 1A)                 | To (Phase 1B+)                                     |
+| ------------------------------- | -------------------------------------------------- |
+| WiFi HTTP commands              | MQTT with TLS for lower latency                    |
+| Pre-shared token                | Mutual TLS or challenge-response                   |
+| Spring-loaded single shot       | CO2-assisted multi-shot carousel                   |
+| Manual operator aiming          | Automated lead calculation from Turret Tracker data|
+| No telemetry beyond heartbeat   | Full telemetry: GPS, altitude, attitude, battery   |
+| ESP32-C3 WiFi only              | ESP32-C6 (WiFi 6 + Thread/802.15.4 mesh)          |
+| Nylon prototype net             | Kevlar net per [manufacturing guide](../kevlar-net-manufacturing) |

--- a/apps/docs/docs/technical/hardware/phase1/drone-net-launcher.md
+++ b/apps/docs/docs/technical/hardware/phase1/drone-net-launcher.md
@@ -5,8 +5,9 @@ sidebar_label: Drone Net Launcher
 sidebar_position: 6
 description:
   Phase 1A build guide for a drone-mounted ESP32-C3 net launcher node. Receives
-  arm/fire commands from the ground station over WiFi. Spring-loaded deployment
-  with servo pin release. Human-in-the-loop only.
+  arm/fire commands from the ground station over WiFi. Two deployment options -
+  gas-ignition pressure (high velocity) or spring-loaded servo release (simple).
+  Human-in-the-loop only.
 difficulty: intermediate
 estimated_reading_time: 8
 points: 15
@@ -26,8 +27,15 @@ prerequisites: ["phase1-hardware-overview", "phase1-trigger-node"]
 # Drone Net Launcher — Air-to-Air Intercept Node
 
 A drone-mounted ESP32-C3 node that receives arm/fire commands from the ground
-station and deploys a lightweight capture net via spring-loaded release. **Single
-shot, human-in-the-loop only.**
+station and deploys a capture net. Two deployment mechanisms are documented:
+
+1. **Gas ignition** (current prototype) — a sealed gas container is ignited
+   electronically, and the rapid pressure build-up ejects the net at high
+   velocity.
+2. **Spring-loaded servo release** (simple alternative) — a compression spring
+   held by a servo-latched pin ejects the net at lower velocity.
+
+**Single shot, human-in-the-loop only.**
 
 ---
 
@@ -63,35 +71,55 @@ right choice for an airborne node.
 
 ## Bill of Materials — Drone Node
 
-| Component        | Part                            | Specification                          | Est. Cost |
-| ---------------- | ------------------------------- | -------------------------------------- | --------- |
-| Compute          | ESP32-C3 SuperMini              | RISC-V, WiFi + BLE 5.0                | $3–4      |
-| Trigger servo    | SG90 micro servo                | Pin-pull release mechanism             | $2        |
-| Power regulator  | Mini buck (MP2307 or AMS1117)   | Drone battery voltage → 3.3V          | $1–2      |
-| Arm switch       | Micro toggle (SPST)             | Physical master arm on drone frame     | $0.50     |
-| Status LED       | 3mm red/green                   | Armed/safe visible from ground         | $0.50     |
-| Net assembly     | Lightweight mesh net            | ~1m², nylon or polyester, corner weights | $5       |
-| Corner weights   | Fishing sinkers or steel nuts   | 4× ~10-15g each                        | $2        |
-| Spring mechanism | Compression spring or bungee    | Deployment force for net ejection      | $2–3      |
-| Release housing  | 3D-printed or lightweight tube  | Holds net + spring, servo-latched lid  | $2–5      |
-| Wiring           | Silicone wire (26AWG), JST-XH   | Lightweight, flexible                  | $2        |
-| **Total**        |                                 |                                        | **$20–30**|
+### Common Components (Both Options)
+
+| Component          | Part                            | Specification                                | Est. Cost |
+| ------------------ | ------------------------------- | -------------------------------------------- | --------- |
+| Compute            | ESP32-C3 SuperMini              | RISC-V, WiFi + BLE 5.0                      | $3–4      |
+| Power regulator    | Mini buck (MP2307 or AMS1117)   | Drone battery voltage → 3.3V for ESP32      | $1–2      |
+| Arm switch         | Micro toggle (SPST)             | Physical master arm on drone frame           | $0.50     |
+| Status LED         | 3mm red/green                   | Armed/safe visible from ground               | $0.50     |
+| Net assembly       | Lightweight mesh net            | ~1m², nylon or polyester, corner weights     | $5        |
+| Corner weights     | Fishing sinkers or steel nuts   | 4× ~10-15g each                              | $2        |
+| Wiring             | Silicone wire (26AWG), JST-XH   | Lightweight, heat-resistant                  | $2        |
+
+### Option A — Gas Ignition (Current Prototype)
+
+| Component          | Part                            | Specification                                | Est. Cost |
+| ------------------ | ------------------------------- | -------------------------------------------- | --------- |
+| Igniter driver     | IRLZ44N MOSFET module           | Logic-level gate, handles igniter current    | $2        |
+| Igniter element    | Nichrome wire or e-match        | Resistive heating element to ignite gas      | $1–3      |
+| Gas container      | Sealed pressure vessel          | Gas-filled, ignites for pressure build-up    | $3–8      |
+| Barrel / tube      | PVC or aluminium tube           | Directs gas pressure to eject net            | $2–5      |
+| Burst disc / seal  | Thin membrane or foil cap       | Contains gas until ignition pressure reached | $1–2      |
+| Pull-down resistor | 10kΩ                            | MOSFET gate safety (prevents floating pin)   | $0.10     |
+| **Option A total** |                                 |                                              | **$23–35**|
+
+### Option B — Spring-Loaded Servo Release (Simple Alternative)
+
+| Component          | Part                            | Specification                                | Est. Cost |
+| ------------------ | ------------------------------- | -------------------------------------------- | --------- |
+| Trigger servo      | SG90 micro servo                | Pin-pull release mechanism                   | $2        |
+| Spring mechanism   | Compression spring or bungee    | Deployment force for net ejection            | $2–3      |
+| Release housing    | 3D-printed or lightweight tube  | Holds net + spring, servo-latched lid        | $2–5      |
+| **Option B total** |                                 |                                              | **$20–28**|
 
 ### Weight Budget
 
-| Component          | Weight   |
-| ------------------ | -------- |
-| ESP32-C3 module    | 5g       |
-| SG90 servo         | 9g       |
-| Buck converter     | 3g       |
-| Wiring + switch    | 5g       |
-| Net (1m² nylon)    | 20-30g   |
-| Corner weights     | 40-60g   |
-| Spring + housing   | 30-50g   |
-| **Total payload**  | **~112-162g** |
+| Component                  | Option A (Gas) | Option B (Spring) |
+| -------------------------- | -------------- | ----------------- |
+| ESP32-C3 module            | 5g             | 5g                |
+| Actuator (MOSFET / servo)  | 8g             | 9g                |
+| Buck converter             | 3g             | 3g                |
+| Wiring + switch            | 5g             | 5g                |
+| Launcher (gas / spring)    | 50-100g        | 30-50g            |
+| Net (1m² nylon)            | 20-30g         | 20-30g            |
+| Corner weights             | 40-60g         | 40-60g            |
+| **Total payload**          | **~131-211g**  | **~112-162g**     |
 
-Most consumer drones (250mm+) can carry 150-300g payload. A 250mm racing quad
-can handle the lower end; a 450mm+ platform handles it comfortably.
+Most consumer drones (250mm+) can carry 150-300g payload. Option B fits a 250mm
+frame; Option A is better suited for a 450mm+ platform with 4S power for
+sufficient thrust margin.
 
 ---
 
@@ -101,22 +129,30 @@ can handle the lower end; a 450mm+ platform handles it comfortably.
   ┌──────────────────────────────────────────────────────────────┐
   │                  Drone Net Launcher Node                      │
   │                                                              │
-  │   Drone Battery ── Mini Buck ── 3.3V ── ESP32-C3             │
-  │                                          │                    │
-  │                                   GPIO ── Micro toggle (arm)  │
-  │                                   GPIO ── Green LED (armed)   │
-  │                                   GPIO ── Red LED (safe)      │
-  │                                   GPIO ── SG90 signal         │
+  │   Drone Battery ──┬── Mini Buck ── 3.3V ── ESP32-C3          │
+  │                   │                         │                 │
+  │                   │                  GPIO ── Micro toggle (arm)│
+  │                   │                  GPIO ── Green LED (armed) │
+  │                   │                  GPIO ── Red LED (safe)    │
+  │                   │                  GPIO ── MOSFET gate       │
+  │                   │                                           │
+  │                   │    ┌─────────────────────────────┐        │
+  │                   │    │ MOSFET (IRLZ44N)            │        │
+  │                   └────┤ Drain ── Igniter element    │        │
+  │                        │ Source ── GND               │        │
+  │                        └─────────────────────────────┘        │
   │                                                              │
   │                    ┌──────────────────────────┐              │
-  │                    │   Net Canister            │              │
+  │                    │   Launch Tube             │              │
   │                    │                          │              │
-  │                    │   ┌── Spring ──┐         │              │
-  │                    │   │   Net      │         │              │
-  │                    │   │  (folded)  │         │              │
-  │                    │   └────────────┘         │              │
-  │                    │        ▲                  │              │
-  │                    │   Servo pin (latch)       │              │
+  │                    │   ┌── Net (folded) ──┐   │              │
+  │                    │   │  corner weights   │   │              │
+  │                    │   └──────────────────┘   │              │
+  │                    │   ┌── Burst disc ────┐   │              │
+  │                    │   └──────────────────┘   │              │
+  │                    │   ┌── Gas container ─┐   │              │
+  │                    │   │  + igniter wire   │   │              │
+  │                    │   └──────────────────┘   │              │
   │                    └──────────────────────────┘              │
   │                                                              │
   │   WiFi ◄── ARM / FIRE commands from ground station           │
@@ -125,46 +161,131 @@ can handle the lower end; a 450mm+ platform handles it comfortably.
   Ground Station (ESP32-S)                    Drone (ESP32-C3)
   ┌───────────────────┐    WiFi (2.4GHz)    ┌───────────────────┐
   │ SkyWatch detect   │ ─────────────────── │ Net Launcher      │
-  │ Turret track      │    ARM / FIRE cmd   │ Servo release     │
+  │ Turret track      │    ARM / FIRE cmd   │ Gas ignition      │
   │ Operator console  │ ◄───────────────── │ Status heartbeat  │
   └───────────────────┘    Status / ACK     └───────────────────┘
 ```
 
 ---
 
-## Deployment Mechanism — Spring-Loaded Pin Release
+## Deployment Mechanisms
 
-The simplest reliable mechanism for a first prototype:
+Two options are documented. Choose based on your risk tolerance, drone platform,
+and engagement range requirements.
+
+### Mechanism Comparison
+
+| Mechanism             | Ejection Velocity  | Weight  | Complexity | Range   | Reloadable          |
+| --------------------- | ------------------ | ------- | ---------- | ------- | ------------------- |
+| **A: Gas ignition**   | **High (50+ m/s)** | Medium  | Medium     | 15-30m  | Yes (new container) |
+| **B: Spring + servo** | Low (5-10 m/s)     | Low     | Low        | 3-8m    | Yes (reset spring)  |
+| CO2 cartridge         | Medium (20-30 m/s) | Medium  | Medium     | 10-20m  | Yes (new cartridge) |
+| Compressed air tank   | Medium (20-40 m/s) | High    | Medium     | 10-25m  | Yes (refill)        |
+
+---
+
+### Option A — Gas Ignition Pressure (Current Prototype)
+
+The current prototype uses a **sealed gas container that is ignited
+electronically**. The rapid combustion creates a pressure pulse that ejects the
+net at high velocity through a launch tube.
+
+#### How It Works
+
+1. **Gas container** is sealed and mounted at the base of the launch tube.
+2. **Nichrome wire or e-match igniter** is embedded in or adjacent to the gas
+   container, wired through a MOSFET to the drone battery.
+3. **Net is folded** above a burst disc / foil seal that separates it from the
+   gas chamber.
+4. On `FIRE` command: ESP32 drives MOSFET gate HIGH → current flows through
+   igniter → gas ignites → pressure builds → burst disc ruptures → net is
+   ejected at high velocity → corner weights spread the net in flight.
+
+#### Sequence Timing
+
+```text
+  FIRE cmd ──▶ MOSFET ON ──▶ Igniter heats ──▶ Gas ignites ──▶ Pressure builds
+   t=0ms         t=1ms         t=5-20ms          t=20-50ms
+
+  ──▶ Burst disc ruptures ──▶ Net ejects ──▶ Net spreads
+        t=30-80ms               t=50-100ms     t=100-300ms
+```
+
+Total time from command to net deployment: **< 100ms** (much faster than
+spring-based or CO2 systems).
+
+#### Gas Container Considerations
+
+- **Container material**: must withstand storage pressure but rupture/vent
+  predictably when ignited. Prototype uses thin-wall sealed containers.
+- **Gas selection**: the gas must be commercially available, storable, and
+  produce sufficient pressure on ignition without excessive blast or shrapnel.
+- **Burst disc calibration**: the burst disc must hold during storage and transit
+  but rupture cleanly at the designed ignition pressure. Too strong = squib
+  (no deployment). Too weak = premature rupture.
+- **Igniter reliability**: nichrome wire is simple and reliable but requires
+  sufficient current (~1-3A for 50-200ms). E-matches are more consistent but
+  single-use. Both work from a LiPo via MOSFET.
+
+:::danger
+**Gas ignition is an energetic event.** Unlike spring or servo mechanisms, this
+system produces heat, pressure, and potentially flame. All testing must be done
+outdoors, away from people, with the operator behind cover. Eye and ear
+protection required. Never point the launch tube at anything you don't intend to
+hit.
+:::
+
+:::warning
+**Regulatory note:** Depending on jurisdiction, gas-ignition launchers may be
+classified as pyrotechnic devices. Check local regulations before building,
+testing, or transporting. This documentation is for a **simulation and training
+platform** — always comply with applicable laws.
+:::
+
+---
+
+### Option B — Spring-Loaded Servo Release (Simple Alternative)
+
+A lower-risk, lower-velocity alternative suitable for close-range intercepts or
+initial bench testing.
+
+#### How It Works
 
 1. **Net is folded** into a lightweight canister (3D-printed tube or PVC cap).
 2. **Compression spring** sits beneath the folded net.
 3. **Servo arm holds a retaining pin** that keeps the spring compressed.
-4. On `FIRE` command: servo rotates → pin withdraws → spring pushes net out →
-   corner weights spread the net in flight.
+4. On `FIRE` command: servo rotates 90° → pin withdraws → spring pushes net
+   out → corner weights spread the net in flight.
 
-### Why Spring + Servo (Not Solenoid or CO2)
+#### Advantages Over Gas Ignition
 
-| Mechanism      | Weight | Reliability | Complexity | Drone-suitable |
-| -------------- | ------ | ----------- | ---------- | -------------- |
-| **Spring + servo** | Low | High       | Low        | **Yes**        |
-| CO2 cartridge  | Medium | Medium      | Medium     | Marginal       |
-| Solenoid       | Medium | High        | Medium     | Marginal       |
-| Pyrotechnic    | Low    | High        | High       | No (regulatory)|
+- No energetics — safe for indoor bench testing and demos
+- No consumables — spring resets, no new gas containers needed
+- No regulatory concerns — purely mechanical
+- Simpler wiring — servo signal wire only, no MOSFET or igniter circuit
+- Lighter total weight (~112-162g vs ~131-211g)
 
-Spring + servo wins: no consumables, no high-current draw, no regulatory issues,
-reloadable.
+#### Limitations
+
+- Much lower ejection velocity (5-10 m/s vs 50+ m/s)
+- Shorter effective range (3-8m vs 15-30m)
+- Requires closer intercept approach — harder operationally
+- Spring force limited by canister size and drone payload capacity
 
 ---
 
 ## Safety Architecture
 
 The drone node inherits and extends the Trigger Node safety model. Airborne
-actuation demands **stricter** safety than ground-based:
+actuation demands **stricter** safety than ground-based — especially for Option A
+(gas ignition), where an accidental ignition cannot be undone.
 
-### Safety Chain (All Must Pass)
+### Safety Chain (All Must Pass — Both Options)
 
 1. **Physical arm switch** — micro toggle on the drone frame. Must be set before
-   takeoff. Pilot physically confirms arming.
+   takeoff. Pilot physically confirms arming. **For Option A, this switch gates
+   power to the MOSFET circuit** — when disarmed, the igniter has no electrical
+   path regardless of software state.
 2. **Software arm state** — firmware mirrors physical switch. Cannot be armed by
    software alone.
 3. **Ground station ARM command** — two-stage: ground sends `ARM`, drone ACKs.
@@ -173,10 +294,29 @@ actuation demands **stricter** safety than ground-based:
 5. **Heartbeat watchdog** — drone expects heartbeat from ground station every
    500ms. If 3 consecutive heartbeats are missed (1.5s), the node reverts to
    **SAFE** state. Loss of comms = safe, not fire.
-6. **Single-shot lockout** — once fired, the node enters SPENT state. Cannot
+6. **Output pull-down** — a 10kΩ pull-down resistor on the MOSFET gate (Option
+   A) or servo signal pin (Option B) ensures the actuator stays OFF if the ESP32
+   reboots, crashes, or enters an undefined GPIO state.
+7. **Single-shot lockout** — once fired, the node enters SPENT state. Cannot
    re-arm without physical reload and power cycle.
-7. **Altitude/orientation guard** (Phase 1B) — future: IMU checks that drone is
+8. **Altitude/orientation guard** (Phase 1B) — future: IMU checks that drone is
    in a reasonable flight attitude before allowing fire.
+
+### Option A — Ignition-Specific Safety
+
+Because gas ignition is an energetic event, these additional precautions apply
+beyond the standard safety chain:
+
+| Hazard                  | Mitigation                                            |
+| ----------------------- | ----------------------------------------------------- |
+| Accidental ignition     | Physical switch gates MOSFET power; pull-down on gate |
+| ESP32 crash / reboot    | Pull-down resistor defaults gate LOW (igniter off)    |
+| Static discharge        | Shielded igniter leads, twisted pair wiring           |
+| Heat near gas container | Igniter leads routed away from container until ready  |
+| Overpressure            | Burst disc sized for expected pressure; vent holes    |
+| Container rupture       | Launch tube contains fragments; tube aimed downward   |
+| Post-fire hot surfaces  | SPENT state prevents handling; cool-down period noted |
+| RF-induced ignition     | Igniter leads kept short; MOSFET off = no current path|
 
 ### State Machine
 
@@ -197,7 +337,7 @@ actuation demands **stricter** safety than ground-based:
                                         │ ground FIRE cmd + token
                                         ▼
                                    ┌─────────┐
-                                   │ FIRING  │ ── servo release (200ms pulse)
+                                   │ FIRING  │ ── igniter / servo actuates
                                    └────┬────┘
                                         │
                                         ▼
@@ -273,7 +413,18 @@ Ground                              Drone
 3. Wire red LED (+ 220Ω resistor) to safe GPIO.
 4. Firmware reads switch on boot and on interrupt — physical switch always wins.
 
-### Step 4 — Servo Trigger
+### Step 4A — Gas Ignition Trigger (Option A)
+
+1. IRLZ44N MOSFET: source → GND, gate → ESP32-C3 GPIO (e.g., GPIO 4).
+2. **10kΩ pull-down resistor** between gate and GND (critical safety).
+3. Nichrome wire / e-match: one lead → drone battery positive (through arm
+   switch), other lead → MOSFET drain.
+4. Physical arm switch in series with the battery-to-igniter path — when OFF, no
+   current can reach the igniter regardless of MOSFET state.
+5. Test with a multimeter: confirm 0V across igniter when arm switch OFF, and 0V
+   when MOSFET gate LOW (even with arm switch ON).
+
+### Step 4B — Servo Trigger (Option B)
 
 1. SG90 signal wire → ESP32-C3 GPIO (e.g., GPIO 4).
 2. SG90 power → 3.3V rail (SG90 operates 4.8-6V but will work at reduced torque
@@ -282,7 +433,19 @@ Ground                              Drone
 4. Fire position: servo rotates 90° → pin withdraws → spring releases.
 5. After fire: servo returns to neutral, but node enters SPENT state regardless.
 
-### Step 5 — Net Canister Assembly
+### Step 5A — Gas Launch Tube Assembly (Option A)
+
+1. **Launch tube**: PVC or aluminium tube, ~50mm diameter, ~120mm long. Open at
+   the top (net exit), sealed at the bottom (gas chamber).
+2. **Gas container**: mounted at the tube base with igniter element inserted.
+3. **Burst disc**: foil or thin membrane between gas chamber and net cavity.
+   Must hold during handling but rupture cleanly at ignition pressure.
+4. **Net folding**: fold net accordion-style with corner weights on the outside,
+   packed above the burst disc.
+5. **Mounting**: secure tube to drone undercarriage pointing downward. Use metal
+   hose clamps or a 3D-printed cradle bolted to the frame.
+
+### Step 5B — Spring Canister Assembly (Option B)
 
 1. **Canister**: lightweight tube (PVC cap, 3D print, or cardboard for
    prototype). ~50mm diameter, ~80mm tall.
@@ -296,13 +459,18 @@ Ground                              Drone
 ### Step 6 — Integration Test
 
 1. **Bench test (no propellers)**: power drone electronics, test full ARM → FIRE
-   sequence. Verify servo actuates, net ejects.
+   sequence. For Option A: **outdoor only, behind cover**. For Option B: can be
+   done on a bench indoors.
 2. **Heartbeat test**: disconnect ground station WiFi → verify drone reverts to
    SAFE within 1.5s.
 3. **Auth test**: send FIRE without token → verify 403 rejection.
 4. **Lockout test**: after firing, attempt re-arm → verify refusal.
-5. **Hover test**: arm drone (propellers on, tethered or low hover), fire net
-   into open area.
+5. **Static fire test** (Option A only): mount launch tube in a fixed jig
+   (not on drone), fire into a safe backstop. Measure ejection velocity and net
+   spread. Inspect tube and gas chamber for damage.
+6. **Hover test**: arm drone (propellers on, tethered or low hover), fire net
+   into open area. For Option A: tethered hover strongly recommended for first
+   flight fire — recoil may affect drone stability.
 
 ---
 
@@ -313,11 +481,15 @@ Ground                              Drone
 - [ ] Two-stage arm: ground ARM command required before FIRE is accepted
 - [ ] Bearer token authentication on all command endpoints
 - [ ] Heartbeat watchdog reverts to SAFE on comms loss (≤1.5s)
-- [ ] Servo actuates on FIRE, deploying the net from the canister
+- [ ] Actuator fires on FIRE command (MOSFET ignition or servo release)
+- [ ] Net ejects from launch tube / canister on actuation
 - [ ] Single-shot lockout: SPENT state after firing, no re-arm without reload
 - [ ] All commands and state transitions are logged with timestamps
-- [ ] Total payload weight ≤ 200g (including net and housing)
-- [ ] Net deploys and spreads to ≥ 0.5m² in bench drop test
+- [ ] Total payload weight ≤ 200g (Option B) or ≤ 250g (Option A)
+- [ ] Net deploys and spreads to ≥ 0.5m² in bench test
+- [ ] (Option A) Static fire test passed: tube intact, no shrapnel, net ejects cleanly
+- [ ] (Option A) MOSFET gate reads 0V when arm switch OFF (multimeter verified)
+- [ ] (Option A) Pull-down resistor installed and verified on MOSFET gate
 
 ---
 
@@ -375,7 +547,7 @@ Below 2:1 the drone becomes sluggish and difficult to maneuver for intercept.
 | ------------------------------- | -------------------------------------------------- |
 | WiFi HTTP commands              | MQTT with TLS for lower latency                    |
 | Pre-shared token                | Mutual TLS or challenge-response                   |
-| Spring-loaded single shot       | CO2-assisted multi-shot carousel                   |
+| Single-shot (gas or spring)     | Multi-shot carousel with reloadable chambers       |
 | Manual operator aiming          | Automated lead calculation from Turret Tracker data|
 | No telemetry beyond heartbeat   | Full telemetry: GPS, altitude, attitude, battery   |
 | ESP32-C3 WiFi only              | ESP32-C6 (WiFi 6 + Thread/802.15.4 mesh)          |

--- a/apps/docs/docs/technical/hardware/phase1/overview.md
+++ b/apps/docs/docs/technical/hardware/phase1/overview.md
@@ -38,12 +38,13 @@ decision follows one principle: _minimal now, refactor later._
 
 ## Phase 1 Product Set
 
-| #   | Product                                       | Purpose                           | Complexity |
-| --- | --------------------------------------------- | --------------------------------- | ---------- |
-| 1   | [SkyWatch Nano](phase1-skywatch-nano)         | Detection + local alarm           | Low        |
-| 2   | [SkyWatch Standard](phase1-skywatch-standard) | Detection + local & remote alerts | Medium     |
-| 3   | [Turret Tracker](phase1-turret-tracker)       | Pan/tilt camera tracking rig      | Medium     |
-| 4   | [Trigger Node](phase1-trigger-node)           | Safe countermeasure placeholder   | Low        |
+| #   | Product                                           | Purpose                            | Complexity   |
+| --- | ------------------------------------------------- | ---------------------------------- | ------------ |
+| 1   | [SkyWatch Nano](phase1-skywatch-nano)             | Detection + local alarm            | Low          |
+| 2   | [SkyWatch Standard](phase1-skywatch-standard)     | Detection + local & remote alerts  | Medium       |
+| 3   | [Turret Tracker](phase1-turret-tracker)           | Pan/tilt camera tracking rig       | Medium       |
+| 4   | [Trigger Node](phase1-trigger-node)               | Safe countermeasure placeholder    | Low          |
+| 5   | [Drone Net Launcher](phase1-drone-net-launcher)   | Air-to-air net intercept node      | Intermediate |
 
 Each product has its own page with buy-now/buy-later tables, wiring steps, and
 acceptance criteria.
@@ -88,6 +89,11 @@ acceptance criteria.
 | 1   | PIR sensor (HC-SR501)                         | Standard (wake-up trigger)                |
 | 2–3 | Active buzzer + high-bright LED + resistors   | All builds                                |
 | 1   | Relay module (opto-isolated) or MOSFET driver | Trigger Node                              |
+| 1   | ESP32-C3 SuperMini                            | Drone Net Launcher                        |
+| 1   | SG90 micro servo (trigger)                    | Drone Net Launcher (pin release)          |
+| 1   | Mini buck converter (AMS1117 3.3V)            | Drone Net Launcher (power from LiPo)      |
+| 1   | Lightweight mesh net + corner weights         | Drone Net Launcher (capture net)          |
+| 1   | Compression spring + canister                 | Drone Net Launcher (deployment mech)      |
 | —   | Dupont wires, screw terminals, project box    | All builds                                |
 
 ### Buy Later

--- a/apps/docs/docs/technical/hardware/phase1/overview.md
+++ b/apps/docs/docs/technical/hardware/phase1/overview.md
@@ -90,10 +90,11 @@ acceptance criteria.
 | 2–3 | Active buzzer + high-bright LED + resistors   | All builds                                |
 | 1   | Relay module (opto-isolated) or MOSFET driver | Trigger Node                              |
 | 1   | ESP32-C3 SuperMini                            | Drone Net Launcher                        |
-| 1   | SG90 micro servo (trigger)                    | Drone Net Launcher (pin release)          |
+| 1   | IRLZ44N MOSFET + igniter                      | Drone Net Launcher (gas ignition option)  |
+| 1   | SG90 micro servo (trigger)                    | Drone Net Launcher (spring option)        |
 | 1   | Mini buck converter (AMS1117 3.3V)            | Drone Net Launcher (power from LiPo)      |
 | 1   | Lightweight mesh net + corner weights         | Drone Net Launcher (capture net)          |
-| 1   | Compression spring + canister                 | Drone Net Launcher (deployment mech)      |
+| 1   | Gas container + launch tube OR spring canister| Drone Net Launcher (deployment mech)      |
 | —   | Dupont wires, screw terminals, project box    | All builds                                |
 
 ### Buy Later

--- a/apps/docs/docs/technical/hardware/phase1/shared-parts.md
+++ b/apps/docs/docs/technical/hardware/phase1/shared-parts.md
@@ -57,6 +57,24 @@ builds. One order covers the entire demo stack.
 
 **Use for:** Turret Tracker and Trigger Node (more GPIO, easier programming).
 
+### ESP32-C3 SuperMini
+
+| Spec      | Value                                    |
+| --------- | ---------------------------------------- |
+| MCU       | RISC-V single-core (160MHz, 400KB SRAM)  |
+| WiFi      | 802.11 b/g/n                             |
+| Bluetooth | BLE 5.0                                  |
+| GPIO      | 15 pins (11 usable after defaults)       |
+| USB       | USB-C (onboard programmer)               |
+| Flash     | 4MB                                      |
+| Power     | 3.3V via USB or pin                      |
+| Weight    | ~5g (bare module)                        |
+
+**Sourcing:** AliExpress, Amazon. ~$3–4 per unit.
+
+**Use for:** Drone Net Launcher (lightest option, low power draw, sufficient GPIO
+for single servo + arm switch + status LEDs).
+
 ---
 
 ## MP1584EN Buck Converter
@@ -205,7 +223,9 @@ builds. One order covers the entire demo stack.
 | -------------------------------- | ------ | ---------- | ------------------- |
 | ESP32-CAM (OV2640)               | 2      | $12–16     | AliExpress / Amazon |
 | ESP32-DevKitC                    | 1      | $5–8       | AliExpress / Amazon |
+| ESP32-C3 SuperMini               | 1      | $3–4       | AliExpress / Amazon |
 | MP1584EN buck converter          | 3      | $3–6       | AliExpress / Amazon |
+| AMS1117 3.3V mini buck           | 1      | $1–2       | AliExpress / Amazon |
 | PCA9685 servo driver             | 1      | $2–4       | AliExpress / Amazon |
 | MG90S servo                      | 2      | $4–6       | AliExpress / Amazon |
 | Pan/tilt bracket kit             | 1      | $2–4       | AliExpress / Amazon |
@@ -222,7 +242,11 @@ builds. One order covers the entire demo stack.
 | USB-TTL adapter                  | 1      | $2–3       | AliExpress / Amazon |
 | Heatshrink + zip ties            | 1 each | $2–3       | AliExpress / Amazon |
 | LED strip (30cm, 12V)            | 1      | $2–4       | AliExpress / Amazon |
+| SG90 micro servo (trigger)       | 1      | $2         | AliExpress / Amazon |
+| Net mesh (1m² nylon) + weights   | 1      | $7         | AliExpress / Amazon |
+| Compression spring + canister    | 1      | $3–5       | AliExpress / Amazon |
+| Silicone wire (26AWG)            | 1m     | $1–2       | AliExpress / Amazon |
 | 12V DC power supply (2A)         | 1      | $5–8       | Amazon              |
-| **Total estimate**               |        | **$55–85** |                     |
+| **Total estimate**               |        | **$75–110**|                     |
 
-This covers all four Phase 1 products with spares.
+This covers all five Phase 1 products with spares (including drone net launcher).

--- a/apps/docs/docs/technical/hardware/phase1/shared-parts.md
+++ b/apps/docs/docs/technical/hardware/phase1/shared-parts.md
@@ -242,11 +242,16 @@ for single servo + arm switch + status LEDs).
 | USB-TTL adapter                  | 1      | $2–3       | AliExpress / Amazon |
 | Heatshrink + zip ties            | 1 each | $2–3       | AliExpress / Amazon |
 | LED strip (30cm, 12V)            | 1      | $2–4       | AliExpress / Amazon |
-| SG90 micro servo (trigger)       | 1      | $2         | AliExpress / Amazon |
+| IRLZ44N MOSFET module            | 1      | $2         | AliExpress / Amazon |
+| Nichrome wire / e-match igniter  | 2      | $2–3       | AliExpress / Amazon |
+| Gas container + burst disc       | 2      | $5–10      | AliExpress / Amazon |
+| PVC / aluminium launch tube      | 1      | $2–5       | Hardware store      |
+| SG90 micro servo (trigger, alt.) | 1      | $2         | AliExpress / Amazon |
+| Compression spring (alt.)        | 1      | $2–3       | AliExpress / Amazon |
 | Net mesh (1m² nylon) + weights   | 1      | $7         | AliExpress / Amazon |
-| Compression spring + canister    | 1      | $3–5       | AliExpress / Amazon |
 | Silicone wire (26AWG)            | 1m     | $1–2       | AliExpress / Amazon |
 | 12V DC power supply (2A)         | 1      | $5–8       | Amazon              |
-| **Total estimate**               |        | **$75–110**|                     |
+| **Total estimate**               |        | **$80–120**|                     |
 
-This covers all five Phase 1 products with spares (including drone net launcher).
+This covers all five Phase 1 products with spares, including both drone net
+launcher options (gas ignition + spring-loaded).

--- a/apps/docs/docs/technical/hardware/phase1/wiring-diagrams.md
+++ b/apps/docs/docs/technical/hardware/phase1/wiring-diagrams.md
@@ -39,6 +39,7 @@ graph TB
         PCA["PCA9685<br/>Servo Driver"]
         PAN["SG90 Pan<br/><i>Ch0 · 0°–180°</i>"]
         TILT["SG90 Tilt<br/><i>Ch1 · 0°–180°</i>"]
+        LORA["SX1276 LoRa<br/><i>868MHz · SPI bus</i>"]
         HLED1["Status LED<br/><i>GPIO2 (blue)</i>"]
         HLED2["MQTT LED<br/><i>GPIO3 (green)</i>"]
     end
@@ -187,7 +188,7 @@ graph LR
     style G15 fill:#006400,stroke:#4caf50,color:#fff
 ```
 
-### ESP32-S3 (Hub + Turret)
+### ESP32-S3 (Hub + Turret + LoRa Gateway)
 
 ```mermaid
 graph LR
@@ -195,8 +196,14 @@ graph LR
         direction TB
         S2["GPIO2 — Status LED<br/><i>→ 220Ω → blue LED</i>"]
         S3["GPIO3 — MQTT LED<br/><i>→ 220Ω → green LED</i>"]
-        S8["GPIO8 — I2C SDA<br/><i>→ PCA9685 SDA (4.7kΩ pull-up)</i>"]
-        S9["GPIO9 — I2C SCL<br/><i>→ PCA9685 SCL (4.7kΩ pull-up)</i>"]
+        S8["GPIO8 — I2C SDA<br/><i>→ PCA9685 (4.7kΩ pull-up)</i>"]
+        S9["GPIO9 — I2C SCL<br/><i>→ PCA9685 (4.7kΩ pull-up)</i>"]
+        S10["GPIO10 — LoRa CS<br/><i>→ SX1276 NSS</i>"]
+        S11["GPIO11 — LoRa MOSI<br/><i>→ SX1276 MOSI</i>"]
+        S12["GPIO12 — LoRa SCK<br/><i>→ SX1276 SCK</i>"]
+        S13["GPIO13 — LoRa MISO<br/><i>→ SX1276 MISO</i>"]
+        S14["GPIO14 — LoRa RST<br/><i>→ SX1276 RST</i>"]
+        S15["GPIO15 — LoRa DIO0<br/><i>→ SX1276 IRQ</i>"]
     end
 
     subgraph PCA9685["PCA9685 Channels"]
@@ -207,17 +214,34 @@ graph LR
         CH3["Ch3 — (spare)"]
     end
 
+    subgraph SX1276["SX1276 LoRa 868MHz"]
+        direction TB
+        LORA_SPI["SPI Bus"]
+        LORA_ANT["Spring Antenna<br/><i>1–10km range</i>"]
+    end
+
     S8 --> PCA9685
     S9 --> PCA9685
+    S10 --> SX1276
+    S11 --> SX1276
+    S12 --> SX1276
+    S13 --> SX1276
 
     style S2 fill:#006400,stroke:#4caf50,color:#fff
     style S3 fill:#006400,stroke:#4caf50,color:#fff
     style S8 fill:#1e3a5f,stroke:#4a90d9,color:#fff
     style S9 fill:#1e3a5f,stroke:#4a90d9,color:#fff
+    style S10 fill:#5f1e5f,stroke:#d94ad9,color:#fff
+    style S11 fill:#5f1e5f,stroke:#d94ad9,color:#fff
+    style S12 fill:#5f1e5f,stroke:#d94ad9,color:#fff
+    style S13 fill:#5f1e5f,stroke:#d94ad9,color:#fff
+    style S14 fill:#5f1e5f,stroke:#d94ad9,color:#fff
+    style S15 fill:#5f1e5f,stroke:#d94ad9,color:#fff
     style CH0 fill:#b8860b,stroke:#ffa500,color:#fff
     style CH1 fill:#b8860b,stroke:#ffa500,color:#fff
     style CH2 fill:#333,stroke:#666,color:#999
     style CH3 fill:#333,stroke:#666,color:#999
+    style SX1276 fill:#4a0e4a,stroke:#d94ad9,color:#fff
 ```
 
 ### ESP32-C3 (Response Relay)
@@ -425,6 +449,38 @@ Each servo connector (3-pin):
     on the PCA9685 screw terminals to absorb servo current spikes.
 ```
 
+### SX1276 LoRa Module → ESP32-S3 Wiring (SPI)
+
+Long-range radio for bridging alerts beyond WiFi range (1–10km). Uses the bare
+SX1276 module (1.27mm castellated pads — solder to breakout or direct wire).
+
+```text
+SX1276 Pin       ESP32-S3 Pin     Notes
+──────────       ────────────     ─────
+VCC            → 3.3V             3.3V ONLY — 5V will destroy the module!
+GND            → GND              Common ground
+SCK            → GPIO12           SPI clock
+MISO           → GPIO13           SPI data out (from SX1276)
+MOSI           → GPIO11           SPI data in (to SX1276)
+NSS (CS)       → GPIO10           Chip select
+RST            → GPIO14           Reset
+DIO0           → GPIO15           Interrupt (RX done / TX done)
+DIO1           — (not connected)  Optional — CAD detection
+DIO2           — (not connected)  Optional — frequency hop
+ANT            → spring antenna   Solder spring antenna to ANT pad
+```
+
+**LoRa Radio Configuration (firmware defaults):**
+
+| Parameter | Value | Notes |
+| --------- | ----- | ----- |
+| Frequency | 868 MHz | SA/EU ISM band (change to 915 for US/AU) |
+| Spreading Factor | SF9 | ~5km range, ~1.7kbps |
+| Bandwidth | 125 kHz | Standard LoRa |
+| TX Power | 17 dBm | Max 20 for SX1276 |
+| Coding Rate | 4/5 | Error correction |
+| Sync Word | 0x34 | Private network |
+
 ### ESP32-S3 Additional Peripherals
 
 ```text
@@ -432,6 +488,12 @@ ESP32-S3 Pin     Connection              Component         Notes
 ────────────     ──────────              ─────────         ─────
 GPIO8          → PCA9685 SDA            I2C data          4.7kΩ pull-up to 3.3V
 GPIO9          → PCA9685 SCL            I2C clock         4.7kΩ pull-up to 3.3V
+GPIO10         → SX1276 NSS            LoRa chip select  SPI
+GPIO11         → SX1276 MOSI           LoRa data in      SPI
+GPIO12         → SX1276 SCK            LoRa clock        SPI
+GPIO13         → SX1276 MISO           LoRa data out     SPI
+GPIO14         → SX1276 RST            LoRa reset
+GPIO15         → SX1276 DIO0           LoRa interrupt    RX/TX done
 GPIO2          → 220Ω → LED anode      Status LED        Blue = hub active
                          cathode → GND
 GPIO3          → 220Ω → LED anode      MQTT LED          Blink on message rx
@@ -512,6 +574,13 @@ GND            ← common GND            Ground              Shared ground
 | SG90 micro servo | 2 (+2 spare) | Pan + tilt | **R60–120** |
 | Pan/tilt bracket (FPV nylon) | 1 | Gimbal mount | **R30–80** |
 
+### LoRa Radio
+
+| Item | Qty | Role | Est. Cost |
+| ---- | --- | ---- | --------- |
+| SX1276/SX1278 LoRa module (868MHz) | 2 | Long-range radio (hub + remote) | **R56–112** |
+| Spring antenna (868MHz) | 2 | Included with module | (included) |
+
 ### Common Components
 
 | Item | Qty | Role | Est. Cost |
@@ -536,8 +605,9 @@ GND            ← common GND            Ground              Shared ground
 | -------- | ---------- |
 | ESP32-CAM | R150–250 |
 | Turret kit (PCA9685 + servos + bracket) | R150–300 |
+| LoRa modules (2x SX1276) | R56–112 |
 | Common components | R140–240 |
-| **Total** | **R440–790** |
+| **Total** | **R496–902** |
 
 ---
 

--- a/apps/docs/docs/technical/hardware/phase1/wiring-diagrams.md
+++ b/apps/docs/docs/technical/hardware/phase1/wiring-diagrams.md
@@ -27,7 +27,227 @@ peripherals) and a **separate 5V supply** for servos.
 
 ---
 
-## System Overview
+## System Topology
+
+```mermaid
+graph TB
+    subgraph HUB["🟦 ESP32-S3 — SkyWatch Hub"]
+        direction TB
+        AP["WiFi Access Point<br/><i>SkyWatch-Hub</i>"]
+        BROKER["MQTT Broker<br/><i>TinyMqtt :1883</i>"]
+        I2C["I2C Bus<br/><i>SDA=GPIO8, SCL=GPIO9</i>"]
+        PCA["PCA9685<br/>Servo Driver"]
+        PAN["SG90 Pan<br/><i>Ch0 · 0°–180°</i>"]
+        TILT["SG90 Tilt<br/><i>Ch1 · 0°–180°</i>"]
+        HLED1["Status LED<br/><i>GPIO2 (blue)</i>"]
+        HLED2["MQTT LED<br/><i>GPIO3 (green)</i>"]
+    end
+
+    subgraph CAM["🟩 ESP32-CAM — SkyWatch Nano"]
+        direction TB
+        OV2640["OV2640 Camera"]
+        MJPEG["MJPEG Stream<br/><i>:81/stream</i>"]
+        DETECT["Motion Detect<br/><i>Frame differencing</i>"]
+        BUZZ1["Buzzer<br/><i>GPIO12 → BC547</i>"]
+        BEACON["LED Beacon<br/><i>GPIO13 (red)</i>"]
+        BTN1["Arm Button<br/><i>GPIO14</i>"]
+        CLED["Status LED<br/><i>GPIO15 (green)</i>"]
+    end
+
+    subgraph RELAY["🟥 ESP32-C3 — Response Relay"]
+        direction TB
+        RLY["5V Relay Module<br/><i>GPIO4 (active LOW)</i>"]
+        LOAD["Dummy Load<br/><i>LED strip / lamp</i>"]
+        ARMED_LED["Armed LED<br/><i>GPIO5 (red)</i>"]
+        BTN2["Arm Button<br/><i>GPIO6</i>"]
+        RLED["Status LED<br/><i>GPIO7 (green)</i>"]
+        BUZZ2["Buzzer<br/><i>GPIO10 → BC547</i>"]
+    end
+
+    CAM -- "WiFi STA" --> AP
+    RELAY -- "WiFi STA" --> AP
+    AP --> BROKER
+    BROKER -- "skywatch/+/detection" --> DETECT
+    BROKER -- "command/relay-001/trigger" --> RLY
+    I2C --> PCA
+    PCA --> PAN
+    PCA --> TILT
+    OV2640 --> DETECT
+    OV2640 --> MJPEG
+    RLY --> LOAD
+
+    style HUB fill:#1e3a5f,stroke:#4a90d9,color:#fff
+    style CAM fill:#1a3d1a,stroke:#4caf50,color:#fff
+    style RELAY fill:#5f1e1e,stroke:#d94a4a,color:#fff
+```
+
+## Data Flow (MQTT Messages)
+
+```mermaid
+sequenceDiagram
+    participant CAM as ESP32-CAM<br/>SkyWatch Nano
+    participant HUB as ESP32-S3<br/>Hub + Broker
+    participant RLY as ESP32-C3<br/>Response Relay
+
+    Note over HUB: Boot first — creates WiFi AP + MQTT broker
+    CAM->>HUB: WiFi connect (STA → AP)
+    RLY->>HUB: WiFi connect (STA → AP)
+    CAM->>HUB: MQTT connect (nano-001)
+    RLY->>HUB: MQTT connect (relay-001)
+
+    loop Every 30s
+        CAM-->>HUB: skywatch/nano-001/status (heartbeat)
+        RLY-->>HUB: skywatch/relay-001/status (heartbeat)
+        HUB-->>HUB: skywatch/hub-001/status (heartbeat)
+    end
+
+    Note over CAM: Motion detected!
+    CAM->>HUB: skywatch/nano-001/detection {event, pixels, ...}
+    HUB->>HUB: Log detection, aim turret
+    HUB->>RLY: command/relay-001/trigger {command: "trigger"}
+    RLY->>RLY: Activate relay (2s pulse)
+    RLY->>HUB: alarm/relay-001/activated {event}
+
+    Note over CAM,RLY: Arm/Disarm (button or remote)
+    HUB->>CAM: command/nano-001/arm {armed: false}
+    HUB->>RLY: command/relay-001/arm {armed: false}
+    CAM-->>HUB: skywatch/nano-001/armed {armed: false}
+    RLY-->>HUB: skywatch/relay-001/armed {armed: false}
+```
+
+## Power Distribution
+
+```mermaid
+graph LR
+    subgraph PSU["Power Supplies"]
+        USB1["USB-C 5V/2A<br/><i>ESP32-S3 + Servos</i>"]
+        USB2["USB 5V/1A<br/><i>ESP32-CAM</i>"]
+        USB3["USB-C 5V/1A<br/><i>ESP32-C3</i>"]
+    end
+
+    subgraph HUB_PWR["Hub Power Rails"]
+        S3_5V["ESP32-S3<br/>5V pin"]
+        PCA_V["PCA9685<br/>V+ screw terminal"]
+        CAP["470µF Cap<br/><i>across V+ / GND</i>"]
+        PCA_V --- CAP
+    end
+
+    subgraph CAM_PWR["Nano Power Rails"]
+        CAM_5V["ESP32-CAM<br/>5V pin"]
+        BUZZ_5V["Buzzer 5V<br/><i>via BC547</i>"]
+    end
+
+    subgraph RELAY_PWR["Relay Power Rails"]
+        C3_5V["ESP32-C3<br/>5V pin"]
+        RLY_5V["Relay VCC<br/>5V"]
+    end
+
+    USB1 --> S3_5V
+    USB1 --> PCA_V
+    USB2 --> CAM_5V
+    USB2 --> BUZZ_5V
+    USB3 --> C3_5V
+    USB3 --> RLY_5V
+
+    GND["⏚ Common GND<br/><i>ALL boards + peripherals</i>"]
+    S3_5V -.- GND
+    PCA_V -.- GND
+    CAM_5V -.- GND
+    C3_5V -.- GND
+
+    style GND fill:#333,stroke:#ff0,color:#ff0,stroke-width:3px
+    style PSU fill:#2a2a2a,stroke:#888,color:#fff
+```
+
+## GPIO Pin Maps
+
+### ESP32-CAM (SkyWatch Nano)
+
+```mermaid
+graph LR
+    subgraph ESP32_CAM["ESP32-CAM GPIO Allocation"]
+        direction TB
+        G0["GPIO0 — Boot mode<br/><i>GND=flash, float=run</i>"]
+        G1["GPIO1 — UART TX<br/><i>→ FTDI RX (programming)</i>"]
+        G3["GPIO3 — UART RX<br/><i>→ FTDI TX (programming)</i>"]
+        G4["GPIO4 — Flash LED<br/><i>Built-in (reserved)</i>"]
+        G12["GPIO12 — Buzzer<br/><i>→ 1kΩ → BC547 → buzzer</i>"]
+        G13["GPIO13 — LED Beacon<br/><i>→ 220Ω → red LED</i>"]
+        G14["GPIO14 — Arm Button<br/><i>← pushbutton (10kΩ pull-up)</i>"]
+        G15["GPIO15 — Status LED<br/><i>→ 220Ω → green LED</i>"]
+    end
+
+    style G0 fill:#555,stroke:#aaa,color:#fff
+    style G1 fill:#555,stroke:#aaa,color:#fff
+    style G3 fill:#555,stroke:#aaa,color:#fff
+    style G4 fill:#8b0000,stroke:#f44,color:#fff
+    style G12 fill:#b8860b,stroke:#ffa500,color:#fff
+    style G13 fill:#b8860b,stroke:#ffa500,color:#fff
+    style G14 fill:#006400,stroke:#4caf50,color:#fff
+    style G15 fill:#006400,stroke:#4caf50,color:#fff
+```
+
+### ESP32-S3 (Hub + Turret)
+
+```mermaid
+graph LR
+    subgraph ESP32_S3["ESP32-S3 GPIO Allocation"]
+        direction TB
+        S2["GPIO2 — Status LED<br/><i>→ 220Ω → blue LED</i>"]
+        S3["GPIO3 — MQTT LED<br/><i>→ 220Ω → green LED</i>"]
+        S8["GPIO8 — I2C SDA<br/><i>→ PCA9685 SDA (4.7kΩ pull-up)</i>"]
+        S9["GPIO9 — I2C SCL<br/><i>→ PCA9685 SCL (4.7kΩ pull-up)</i>"]
+    end
+
+    subgraph PCA9685["PCA9685 Channels"]
+        direction TB
+        CH0["Ch0 — SG90 Pan<br/><i>0°–180° yaw</i>"]
+        CH1["Ch1 — SG90 Tilt<br/><i>30°–150° pitch</i>"]
+        CH2["Ch2 — (spare)"]
+        CH3["Ch3 — (spare)"]
+    end
+
+    S8 --> PCA9685
+    S9 --> PCA9685
+
+    style S2 fill:#006400,stroke:#4caf50,color:#fff
+    style S3 fill:#006400,stroke:#4caf50,color:#fff
+    style S8 fill:#1e3a5f,stroke:#4a90d9,color:#fff
+    style S9 fill:#1e3a5f,stroke:#4a90d9,color:#fff
+    style CH0 fill:#b8860b,stroke:#ffa500,color:#fff
+    style CH1 fill:#b8860b,stroke:#ffa500,color:#fff
+    style CH2 fill:#333,stroke:#666,color:#999
+    style CH3 fill:#333,stroke:#666,color:#999
+```
+
+### ESP32-C3 (Response Relay)
+
+```mermaid
+graph LR
+    subgraph ESP32_C3["ESP32-C3 GPIO Allocation"]
+        direction TB
+        C4["GPIO4 — Relay<br/><i>→ relay IN (active LOW)</i>"]
+        C5["GPIO5 — Armed LED<br/><i>→ 220Ω → red LED</i>"]
+        C6["GPIO6 — Arm Button<br/><i>← pushbutton (10kΩ pull-up)</i>"]
+        C7["GPIO7 — Status LED<br/><i>→ 220Ω → green LED</i>"]
+        C10["GPIO10 — Buzzer<br/><i>→ 1kΩ → BC547 → buzzer</i>"]
+    end
+
+    subgraph RELAY_OUT["Relay Output"]
+        COM["COM → load (+)"]
+        NO["NO → load return"]
+    end
+
+    C4 --> RELAY_OUT
+
+    style C4 fill:#8b0000,stroke:#f44,color:#fff
+    style C5 fill:#8b0000,stroke:#f44,color:#fff
+    style C6 fill:#006400,stroke:#4caf50,color:#fff
+    style C7 fill:#006400,stroke:#4caf50,color:#fff
+    style C10 fill:#b8860b,stroke:#ffa500,color:#fff
+```
+
+## System Overview (Text Reference)
 
 ```text
 ┌────────────────────┐       WiFi (MQTT)       ┌─────────────────────┐

--- a/apps/docs/docs/technical/hardware/phase1/wiring-diagrams.md
+++ b/apps/docs/docs/technical/hardware/phase1/wiring-diagrams.md
@@ -1,0 +1,365 @@
+---
+id: phase1-wiring-diagrams
+title: "Phase 1 Wiring Diagrams: Three-Node ESP32 Network"
+sidebar_label: Wiring Diagrams
+sidebar_position: 9
+description:
+  Complete wiring diagrams for the Phase 1 three-node ESP32 demo — ESP32-CAM
+  (SkyWatch Nano), ESP32-S3 (Hub + Turret), and ESP32-C3 (Response Relay).
+difficulty: beginner
+estimated_reading_time: 10
+points: 15
+tags:
+  - hardware
+  - phase-1
+  - esp32
+  - wiring
+  - diagrams
+phase: ["seed"]
+prerequisites: ["phase1-hardware-overview"]
+---
+
+# Phase 1 Wiring Diagrams
+
+Complete wiring reference for the three-node ESP32 Phase 1 demo stack. All
+connections assume **no SD card** on the ESP32-CAM (frees GPIO12–15 for
+peripherals) and a **separate 5V supply** for servos.
+
+---
+
+## System Overview
+
+```text
+┌────────────────────┐       WiFi (MQTT)       ┌─────────────────────┐
+│   ESP32-CAM        │◄────────────────────────►│   ESP32-S3          │
+│   SkyWatch Nano    │  skywatch/nano/detection  │   Hub + Turret      │
+│   (camera node)    │  skywatch/nano/status      │   (WiFi AP + MQTT   │
+│                    │                            │    broker + I2C     │
+│   Peripherals:     │                            │    servo control)   │
+│   - Buzzer (GPIO12)│                            │                     │
+│   - LED    (GPIO13)│                            │   Peripherals:      │
+│   - Button (GPIO14)│                            │   - PCA9685 (I2C)   │
+│   - Status (GPIO15)│                            │   - SG90 pan  (Ch0) │
+└────────────────────┘                            │   - SG90 tilt (Ch1) │
+                                                  │   - Status LED      │
+                                                  └──────────┬──────────┘
+                                                             │ MQTT
+                                                  ┌──────────┴──────────┐
+                                                  │   ESP32-C3          │
+                                                  │   Response Relay    │
+                                                  │   (alarm node)      │
+                                                  │                     │
+                                                  │   Peripherals:      │
+                                                  │   - Relay/MOSFET    │
+                                                  │   - LED (dummy load)│
+                                                  │   - Arm switch      │
+                                                  │   - Status LED      │
+                                                  └─────────────────────┘
+```
+
+---
+
+## Node 1: ESP32-CAM — SkyWatch Nano (Detection)
+
+Camera-equipped detection node. Captures frames, streams over WiFi, publishes
+detection events to MQTT.
+
+### Pinout Reference (ESP-32S / ESP32-CAM)
+
+```text
+Left side:                    Right side:
+  GPIO4  (HS2_DATA1)           GND
+  GPIO2  (HS2_DATA0)           GPIO1  (U0TXD)
+  GPIO14 (HS2_CLK)             GPIO3  (U0RXD)
+  GPIO15 (HS2_CMD)             3.3V/5V
+  GPIO13 (HS2_DATA3)           GND
+  GPIO12 (HS2_DATA2)           GPIO0  (CSI_MCLK)
+  GND                          GPIO16 (U2RXD)
+  5V                           3.3V
+```
+
+### Peripheral Wiring
+
+```text
+ESP32-CAM Pin    Connection              Component         Notes
+─────────────    ──────────              ─────────         ─────
+GPIO12         → 1kΩ → BC547 base       Active buzzer     NPN transistor driver
+                       collector → buzz(-)                  buzz(+) → 5V
+                       emitter → GND
+
+GPIO13         → 220Ω → LED anode       LED beacon        High-bright red/amber
+                         cathode → GND                     Visual alarm indicator
+
+GPIO14         → pushbutton → GND       Arm/disarm        10kΩ pull-up to 3.3V
+                                                           Press = LOW = toggle
+
+GPIO15         → 220Ω → LED anode       Status LED        Green = connected
+                         cathode → GND                     Blink = detecting
+
+GPIO4          — (reserved)             Built-in flash    Do not reassign
+GPIO0          — float (run) / GND      Boot mode         GND only during flash
+GPIO1 (TX)     → FTDI RX               Programming       Disconnect after flash
+GPIO3 (RX)     → FTDI TX               Programming       Disconnect after flash
+
+5V             ← 5V supply              Power in          USB or buck converter
+GND            ← common GND            Ground             Shared with all nodes
+```
+
+### Buzzer Circuit Detail
+
+```text
+                    5V
+                     │
+                  Buzzer (+)
+                     │
+                  Buzzer (-)
+                     │
+               ┌─── Collector
+               │
+  GPIO12 ─── 1kΩ ─── Base     (BC547 NPN)
+               │
+               └─── Emitter
+                     │
+                    GND
+```
+
+### Programming Setup (FTDI USB-TTL)
+
+```text
+ESP32-CAM        FTDI Adapter
+─────────        ────────────
+5V          ───→ VCC (jumper set to 5V)
+GND         ───→ GND
+GPIO1 (TX)  ───→ RX
+GPIO3 (RX)  ───→ TX
+GPIO0       ───→ GND (during upload only, then disconnect)
+
+Flash procedure:
+  1. Connect GPIO0 to GND
+  2. Press RST button on ESP32-CAM
+  3. Upload firmware via Arduino IDE / PlatformIO
+  4. Disconnect GPIO0 from GND
+  5. Press RST to run firmware
+```
+
+---
+
+## Node 2: ESP32-S3 — Hub + Turret Controller
+
+Central coordinator. Runs WiFi access point, lightweight MQTT broker, and
+controls pan/tilt servos via PCA9685 I2C servo driver.
+
+### PCA9685 → ESP32-S3 Wiring
+
+```text
+PCA9685 Pin      ESP32-S3 Pin     Notes
+───────────      ────────────     ─────
+VCC (logic)    → 3.3V             Logic supply (NOT servo power)
+GND            → GND              Common ground
+SDA            → GPIO8            I2C data
+SCL            → GPIO9            I2C clock
+OE             — (float or GND)   Output enable (LOW = enabled)
+
+V+ (screw terminal) → 5V servo supply   Separate PSU, 5V/2A minimum
+GND (screw terminal) → Common GND        MUST tie to ESP32 GND
+```
+
+### Servo Connections (PCA9685 headers)
+
+```text
+PCA9685 Channel   Servo       Role         Angle Range
+───────────────   ─────       ────         ───────────
+Channel 0         SG90 #1     Pan (yaw)    0°–180°
+Channel 1         SG90 #2     Tilt (pitch) 0°–180°
+Channel 2         (spare)     Future use   —
+Channel 3         (spare)     Future use   —
+
+Each servo connector (3-pin):
+  Orange wire → PWM signal (from PCA9685)
+  Red wire    → V+ (from PCA9685 V+ rail, NOT ESP32)
+  Brown wire  → GND (from PCA9685 GND rail)
+```
+
+### Power Architecture
+
+```text
+                    ┌──────────────────────────────┐
+                    │     5V / 2A Power Supply      │
+                    │     (phone charger or buck)    │
+                    └──────────┬───────────────────┘
+                               │
+                    ┌──────────┴───────────────────┐
+                    │                               │
+              ┌─────┴─────┐                 ┌──────┴──────┐
+              │ PCA9685   │                 │  ESP32-S3   │
+              │ V+ screw  │                 │  5V pin     │
+              │ terminal  │                 │  (or USB)   │
+              └─────┬─────┘                 └──────┬──────┘
+                    │                               │
+                    └──────────┬────────────────────┘
+                               │
+                              GND (common)
+
+    IMPORTANT: Servo V+ rail and ESP32 must share common GND.
+    Add 470–1000µF electrolytic capacitor across V+ and GND
+    on the PCA9685 screw terminals to absorb servo current spikes.
+```
+
+### ESP32-S3 Additional Peripherals
+
+```text
+ESP32-S3 Pin     Connection              Component         Notes
+────────────     ──────────              ─────────         ─────
+GPIO8          → PCA9685 SDA            I2C data          4.7kΩ pull-up to 3.3V
+GPIO9          → PCA9685 SCL            I2C clock         4.7kΩ pull-up to 3.3V
+GPIO2          → 220Ω → LED anode      Status LED        Blue = hub active
+                         cathode → GND
+GPIO3          → 220Ω → LED anode      MQTT LED          Blink on message rx
+                         cathode → GND
+```
+
+---
+
+## Node 3: ESP32-C3 — Response Relay
+
+Receives arm/disarm and trigger commands via MQTT. Drives safe demo outputs
+(LED, lamp, buzzer) via relay or MOSFET. No launcher hardware.
+
+### ESP32-C3 Wiring
+
+```text
+ESP32-C3 Pin     Connection              Component          Notes
+────────────     ──────────              ─────────          ─────
+GPIO4          → relay module IN         5V relay module    Active LOW trigger
+                 relay VCC → 5V                             Or use MOSFET board
+                 relay GND → GND
+                 relay NO/COM → LED/lamp  Dummy load        Safe output only
+
+GPIO5          → 220Ω → LED anode       Armed status LED   Red = armed
+                         cathode → GND                      Off = disarmed
+
+GPIO6          → pushbutton → GND       Arm/disarm switch  10kΩ pull-up to 3.3V
+                                                            Physical safety
+
+GPIO7          → 220Ω → LED anode       Status LED         Green = connected
+                         cathode → GND                      Blink = MQTT active
+
+GPIO10         → 1kΩ → BC547 base       Buzzer (optional)  Same circuit as CAM
+                        collector → buzz(-)
+                        emitter → GND
+
+5V             ← 5V supply              Power in           USB-C or buck
+GND            ← common GND            Ground              Shared ground
+```
+
+### Relay Circuit Detail
+
+```text
+                    5V supply
+                     │
+              ┌──────┴──────┐
+              │  Relay VCC  │
+              │             │
+              │  Relay      │───→ COM ──→ LED strip / lamp (+)
+  GPIO4 ────→│  IN         │───→ NO  ──→ (return through load to GND)
+              │             │
+              │  Relay GND  │
+              └──────┬──────┘
+                     │
+                    GND (common)
+
+    Alternative: MOSFET board (IRF520 or similar)
+    for PWM dimming capability on the dummy load.
+```
+
+---
+
+## Bill of Materials (Phase 1 Complete)
+
+### Boards (already owned)
+
+| Item | Qty | Role | Est. Cost |
+| ---- | --- | ---- | --------- |
+| ESP32-S3 dev board | 1 | Hub + turret brain | (owned) |
+| ESP32-C3 dev board | 1 | Response relay | (owned) |
+| ESP32-CAM (OV2640) | 1 | Camera detection node | **R150–250** |
+
+### Turret Kit
+
+| Item | Qty | Role | Est. Cost |
+| ---- | --- | ---- | --------- |
+| PCA9685 16-ch servo driver | 1 | I2C PWM controller | **R60–100** |
+| SG90 micro servo | 2 (+2 spare) | Pan + tilt | **R60–120** |
+| Pan/tilt bracket (FPV nylon) | 1 | Gimbal mount | **R30–80** |
+
+### Common Components
+
+| Item | Qty | Role | Est. Cost |
+| ---- | --- | ---- | --------- |
+| BC547 NPN transistor | 3 | Buzzer/relay drivers | R5 |
+| 1kΩ resistor | 5 | Base resistors | R2 |
+| 220Ω resistor | 6 | LED current limiting | R2 |
+| 10kΩ resistor | 3 | Pull-ups for buttons | R2 |
+| 5mm LEDs (red, green, blue) | 6 | Status indicators | R5 |
+| Active buzzer (5V) | 2 | Audio alarm | R10 |
+| Pushbutton (momentary) | 2 | Arm/disarm switches | R5 |
+| 5V relay module | 1 | Response relay output | R15–30 |
+| 470µF electrolytic cap | 1 | Servo rail decoupling | R3 |
+| FTDI USB-TTL adapter | 1 | ESP32-CAM programming | R30–60 |
+| Jumper wires (M-F, M-M) | 40 | Connections | R15–30 |
+| Breadboard (half-size) | 2 | Prototyping | R20–40 |
+| 5V/2A USB charger | 1 | Servo power supply | R30–50 |
+
+### Estimated Total (new purchases only)
+
+| Category | Cost (ZAR) |
+| -------- | ---------- |
+| ESP32-CAM | R150–250 |
+| Turret kit (PCA9685 + servos + bracket) | R150–300 |
+| Common components | R140–240 |
+| **Total** | **R440–790** |
+
+---
+
+## Safety Notes
+
+1. **Common ground is mandatory.** All power supplies, ESP32 boards, PCA9685,
+   relay modules, and peripherals must share a single ground reference.
+2. **Set buck converter voltage before connecting.** Adjust MP1584EN or similar
+   to 5.0–5.1V with no load, then connect.
+3. **Bulk capacitor on servo rail.** 470–1000µF across PCA9685 V+ and GND to
+   absorb current spikes when servos move.
+4. **Never power servos from ESP32.** 4 SG90s draw ~2A under load; the ESP32's
+   3.3V regulator cannot supply this.
+5. **GPIO0 on ESP32-CAM.** Must be LOW (GND) for flash mode, floating for run
+   mode. Do not connect permanently to GND.
+6. **No launcher or harmful hardware.** Phase 1 response relay drives LEDs,
+   lamps, or buzzers only. See
+   [safety boundary](../../docs-staging/engineering/phase1/safety-boundary.mdx).
+
+---
+
+## MQTT Topic Map
+
+All three nodes communicate via these topics:
+
+```text
+skywatch/{node_id}/detection    → CAM publishes detection events (QoS 0)
+skywatch/{node_id}/status       → All nodes publish heartbeat (QoS 0)
+skywatch/{node_id}/armed        → Nodes publish arm/disarm state (QoS 1)
+command/{node_id}/aim           → Hub → turret: pan/tilt angles (QoS 1)
+command/{node_id}/trigger       → Hub → relay: activate output (QoS 1)
+command/{node_id}/arm           → Hub → any: arm/disarm command (QoS 1)
+command/{node_id}/config        → Hub → any: config update (QoS 1)
+alarm/{node_id}/activated       → Relay publishes when triggered (QoS 1)
+```
+
+---
+
+## Next Steps
+
+1. Flash firmware to each ESP32 (see `apps/firmware/` for source)
+2. Power up ESP32-S3 first (creates WiFi AP + MQTT broker)
+3. Connect ESP32-CAM — verify camera stream and MQTT detection events
+4. Connect ESP32-C3 — verify relay triggers on MQTT command
+5. Mount servos on pan/tilt bracket, verify aim commands move turret

--- a/apps/firmware/CLAUDE.md
+++ b/apps/firmware/CLAUDE.md
@@ -1,0 +1,51 @@
+# Firmware — Claude Code Context
+
+## Overview
+
+ESP32 firmware for the Phase 1 three-node demo stack. PlatformIO projects using
+Arduino framework, targeting ESP32-CAM, ESP32-S3, and ESP32-C3.
+
+## Structure
+
+```text
+apps/firmware/
+  skywatch-nano/     # ESP32-CAM — camera + detection + MQTT publish
+  skywatch-hub/      # ESP32-S3 — WiFi AP + MQTT broker + PCA9685 turret
+  response-relay/    # ESP32-C3 — MQTT subscribe + relay/LED actuation
+```
+
+## Build & Flash
+
+Requires PlatformIO CLI or PlatformIO IDE extension.
+
+```bash
+# Build all
+cd apps/firmware/skywatch-nano && pio run
+cd apps/firmware/skywatch-hub && pio run
+cd apps/firmware/response-relay && pio run
+
+# Flash (connect board via USB)
+cd apps/firmware/skywatch-nano && pio run -t upload
+cd apps/firmware/skywatch-hub && pio run -t upload
+cd apps/firmware/response-relay && pio run -t upload
+
+# Serial monitor
+pio device monitor -b 115200
+```
+
+## MQTT Topics
+
+```text
+skywatch/{node_id}/detection    # Detection events (CAM → Hub)
+skywatch/{node_id}/status       # Heartbeat (All → Hub)
+skywatch/{node_id}/armed        # Arm state changes (All → Hub)
+command/{node_id}/aim           # Pan/tilt command (Hub → Turret)
+command/{node_id}/trigger       # Relay activation (Hub → Relay)
+command/{node_id}/arm           # Arm/disarm (Hub → Any)
+alarm/{node_id}/activated       # Alarm fired (Relay → Hub)
+```
+
+## Hardware
+
+See `apps/docs/docs/technical/hardware/phase1/wiring-diagrams.md` for full
+wiring reference.

--- a/apps/firmware/response-relay/include/config.h
+++ b/apps/firmware/response-relay/include/config.h
@@ -1,0 +1,46 @@
+#pragma once
+
+// ── Node identity ──────────────────────────────────────────────────
+#ifndef NODE_ID
+#define NODE_ID "relay-001"
+#endif
+
+// ── WiFi (connects to Hub AP) ──────────────────────────────────────
+#ifndef WIFI_SSID
+#define WIFI_SSID "SkyWatch-Hub"
+#endif
+#ifndef WIFI_PASS
+#define WIFI_PASS "phoenix2026"
+#endif
+
+// ── MQTT ───────────────────────────────────────────────────────────
+#ifndef MQTT_BROKER
+#define MQTT_BROKER "192.168.4.1"
+#endif
+#define MQTT_PORT 1883
+
+// Topics
+#define TOPIC_STATUS     "skywatch/" NODE_ID "/status"
+#define TOPIC_ARMED      "skywatch/" NODE_ID "/armed"
+#define TOPIC_ALARM      "alarm/" NODE_ID "/activated"
+#define TOPIC_CMD_TRIG   "command/" NODE_ID "/trigger"
+#define TOPIC_CMD_ARM    "command/" NODE_ID "/arm"
+#define TOPIC_CMD_CFG    "command/" NODE_ID "/config"
+
+// ── GPIO pins (ESP32-C3) ──────────────────────────────────────────
+#define PIN_RELAY         4    // Relay module IN (active LOW)
+#define PIN_LED_ARMED     5    // Red LED — armed status
+#define PIN_BTN_ARM       6    // Arm/disarm pushbutton (active LOW)
+#define PIN_LED_STATUS    7    // Green LED — connection status
+#define PIN_BUZZER       10    // NPN → buzzer (optional)
+
+// ── Relay behaviour ────────────────────────────────────────────────
+#define RELAY_ACTIVE_LOW  true   // Most relay modules are active LOW
+#define RELAY_PULSE_MS    2000   // How long relay stays on per trigger
+#define RELAY_COOLDOWN_MS 5000   // Min time between triggers
+
+// ── Timing ─────────────────────────────────────────────────────────
+#define HEARTBEAT_INTERVAL_MS  30000
+#define DEBOUNCE_MS            200
+#define MQTT_RECONNECT_MS      5000
+#define WIFI_RECONNECT_MS      10000

--- a/apps/firmware/response-relay/platformio.ini
+++ b/apps/firmware/response-relay/platformio.ini
@@ -1,0 +1,15 @@
+[env:esp32c3]
+platform = espressif32
+board = esp32-c3-devkitm-1
+framework = arduino
+monitor_speed = 115200
+upload_speed = 921600
+lib_deps =
+    knolleary/PubSubClient@^2.8
+    bblanchon/ArduinoJson@^7.0
+build_flags =
+    -DNODE_ID=\"relay-001\"
+    -DWIFI_SSID=\"SkyWatch-Hub\"
+    -DWIFI_PASS=\"phoenix2026\"
+    -DMQTT_BROKER=\"192.168.4.1\"
+    -DARDUINO_USB_CDC_ON_BOOT=1

--- a/apps/firmware/response-relay/src/main.cpp
+++ b/apps/firmware/response-relay/src/main.cpp
@@ -1,0 +1,318 @@
+/**
+ * Response Relay — ESP32-C3 Safe Actuation Node
+ *
+ * Phase 1 firmware for the response relay. Receives trigger commands
+ * via MQTT and drives safe demo outputs (relay → LED/lamp, buzzer).
+ * Physical arm/disarm switch prevents accidental activation.
+ *
+ * Hardware: ESP32-C3, relay module, LEDs, buzzer, pushbutton.
+ * Safety:   No launcher or harmful hardware. Relay drives dummy load only.
+ */
+
+#include <Arduino.h>
+#include <WiFi.h>
+#include <PubSubClient.h>
+#include <ArduinoJson.h>
+#include "config.h"
+
+// ── Globals ────────────────────────────────────────────────────────
+WiFiClient wifiClient;
+PubSubClient mqtt(wifiClient);
+
+bool armed = false;  // Start disarmed for safety
+bool relayActive = false;
+bool lastButtonState = HIGH;
+
+unsigned long relayOnMs = 0;
+unsigned long lastTriggerMs = 0;
+unsigned long lastHeartbeatMs = 0;
+unsigned long lastMqttAttemptMs = 0;
+unsigned long lastWifiAttemptMs = 0;
+unsigned long lastButtonCheckMs = 0;
+uint32_t triggerCount = 0;
+
+// ── Forward declarations ───────────────────────────────────────────
+void setupPins();
+void setupWifi();
+void setupMqtt();
+void onMqttMessage(char *topic, byte *payload, unsigned int length);
+void handleTrigger(const char *payload, size_t length);
+void activateRelay();
+void deactivateRelay();
+void publishHeartbeat();
+void publishArmedState();
+void publishAlarm();
+void checkButton();
+void setRelay(bool on);
+
+// ════════════════════════════════════════════════════════════════════
+// Setup
+// ════════════════════════════════════════════════════════════════════
+
+void setup() {
+    Serial.begin(115200);
+    Serial.println("\n[Response Relay] Booting...");
+    Serial.printf("[Response Relay] Node ID: %s\n", NODE_ID);
+
+    setupPins();
+    setupWifi();
+    setupMqtt();
+
+    Serial.println("[Response Relay] Ready. DISARMED by default.");
+    Serial.println("[Response Relay] Press arm button or send MQTT arm command.");
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Main loop
+// ════════════════════════════════════════════════════════════════════
+
+void loop() {
+    unsigned long now = millis();
+
+    // WiFi reconnect
+    if (WiFi.status() != WL_CONNECTED) {
+        digitalWrite(PIN_LED_STATUS, LOW);
+        if (now - lastWifiAttemptMs > WIFI_RECONNECT_MS) {
+            lastWifiAttemptMs = now;
+            Serial.println("[WiFi] Reconnecting...");
+            WiFi.begin(WIFI_SSID, WIFI_PASS);
+        }
+        return;
+    }
+
+    // MQTT reconnect
+    if (!mqtt.connected()) {
+        if (now - lastMqttAttemptMs > MQTT_RECONNECT_MS) {
+            lastMqttAttemptMs = now;
+            Serial.println("[MQTT] Connecting...");
+            if (mqtt.connect(NODE_ID)) {
+                Serial.println("[MQTT] Connected.");
+                mqtt.subscribe(TOPIC_CMD_TRIG);
+                mqtt.subscribe(TOPIC_CMD_ARM);
+                mqtt.subscribe(TOPIC_CMD_CFG);
+                publishArmedState();
+                publishHeartbeat();
+            }
+        }
+    }
+    mqtt.loop();
+
+    // Check arm/disarm button
+    checkButton();
+
+    // Auto-deactivate relay after pulse duration
+    if (relayActive && (now - relayOnMs > RELAY_PULSE_MS)) {
+        deactivateRelay();
+    }
+
+    // Heartbeat
+    if (now - lastHeartbeatMs > HEARTBEAT_INTERVAL_MS) {
+        lastHeartbeatMs = now;
+        publishHeartbeat();
+    }
+
+    // Status LED: solid = connected, blink = connected + armed
+    if (armed) {
+        digitalWrite(PIN_LED_STATUS, (now / 300) % 2);
+    } else {
+        digitalWrite(PIN_LED_STATUS, mqtt.connected() ? HIGH : LOW);
+    }
+
+    // Armed LED
+    digitalWrite(PIN_LED_ARMED, armed ? HIGH : LOW);
+}
+
+// ════════════════════════════════════════════════════════════════════
+// GPIO setup
+// ════════════════════════════════════════════════════════════════════
+
+void setupPins() {
+    pinMode(PIN_RELAY, OUTPUT);
+    pinMode(PIN_LED_ARMED, OUTPUT);
+    pinMode(PIN_LED_STATUS, OUTPUT);
+    pinMode(PIN_BUZZER, OUTPUT);
+    pinMode(PIN_BTN_ARM, INPUT_PULLUP);
+
+    // Ensure relay is OFF at boot
+    setRelay(false);
+    digitalWrite(PIN_LED_ARMED, LOW);
+    digitalWrite(PIN_LED_STATUS, LOW);
+    digitalWrite(PIN_BUZZER, LOW);
+}
+
+// ════════════════════════════════════════════════════════════════════
+// WiFi
+// ════════════════════════════════════════════════════════════════════
+
+void setupWifi() {
+    Serial.printf("[WiFi] Connecting to %s\n", WIFI_SSID);
+    WiFi.mode(WIFI_STA);
+    WiFi.begin(WIFI_SSID, WIFI_PASS);
+
+    int attempts = 0;
+    while (WiFi.status() != WL_CONNECTED && attempts < 20) {
+        delay(500);
+        Serial.print(".");
+        attempts++;
+    }
+
+    if (WiFi.status() == WL_CONNECTED) {
+        Serial.printf("\n[WiFi] Connected. IP: %s\n", WiFi.localIP().toString().c_str());
+    } else {
+        Serial.println("\n[WiFi] Failed. Will retry in loop.");
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════
+// MQTT
+// ════════════════════════════════════════════════════════════════════
+
+void setupMqtt() {
+    mqtt.setServer(MQTT_BROKER, MQTT_PORT);
+    mqtt.setCallback(onMqttMessage);
+    mqtt.setBufferSize(512);
+}
+
+void onMqttMessage(char *topic, byte *payload, unsigned int length) {
+    char msg[256];
+    size_t copyLen = min((unsigned int)255, length);
+    memcpy(msg, payload, copyLen);
+    msg[copyLen] = '\0';
+
+    Serial.printf("[MQTT] %s: %s\n", topic, msg);
+
+    if (strcmp(topic, TOPIC_CMD_TRIG) == 0) {
+        handleTrigger(msg, copyLen);
+    } else if (strcmp(topic, TOPIC_CMD_ARM) == 0) {
+        JsonDocument doc;
+        if (deserializeJson(doc, msg) == DeserializationError::Ok) {
+            if (doc.containsKey("armed")) {
+                armed = doc["armed"].as<bool>();
+                Serial.printf("[ARM] Remote set armed=%s\n", armed ? "true" : "false");
+                publishArmedState();
+                if (!armed) {
+                    deactivateRelay();
+                }
+            }
+        }
+    }
+}
+
+void handleTrigger(const char *payload, size_t length) {
+    unsigned long now = millis();
+
+    if (!armed) {
+        Serial.println("[TRIGGER] Ignored — not armed.");
+        return;
+    }
+
+    if (now - lastTriggerMs < RELAY_COOLDOWN_MS) {
+        Serial.println("[TRIGGER] Ignored — cooldown active.");
+        return;
+    }
+
+    Serial.println("[TRIGGER] Activating relay!");
+    lastTriggerMs = now;
+    triggerCount++;
+    activateRelay();
+    publishAlarm();
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Relay control
+// ════════════════════════════════════════════════════════════════════
+
+void setRelay(bool on) {
+    if (RELAY_ACTIVE_LOW) {
+        digitalWrite(PIN_RELAY, on ? LOW : HIGH);
+    } else {
+        digitalWrite(PIN_RELAY, on ? HIGH : LOW);
+    }
+}
+
+void activateRelay() {
+    relayActive = true;
+    relayOnMs = millis();
+    setRelay(true);
+    digitalWrite(PIN_BUZZER, HIGH);
+    Serial.printf("[RELAY] ON (pulse %dms)\n", RELAY_PULSE_MS);
+}
+
+void deactivateRelay() {
+    if (!relayActive) return;
+    relayActive = false;
+    setRelay(false);
+    digitalWrite(PIN_BUZZER, LOW);
+    Serial.println("[RELAY] OFF");
+}
+
+// ════════════════════════════════════════════════════════════════════
+// MQTT Publishing
+// ════════════════════════════════════════════════════════════════════
+
+void publishHeartbeat() {
+    JsonDocument doc;
+    doc["node_id"] = NODE_ID;
+    doc["type"] = "heartbeat";
+    doc["role"] = "relay";
+    doc["uptime_ms"] = millis();
+    doc["armed"] = armed;
+    doc["relay_active"] = relayActive;
+    doc["trigger_count"] = triggerCount;
+    doc["wifi_rssi"] = WiFi.RSSI();
+    doc["free_heap"] = ESP.getFreeHeap();
+
+    char buf[256];
+    serializeJson(doc, buf, sizeof(buf));
+    mqtt.publish(TOPIC_STATUS, buf);
+}
+
+void publishArmedState() {
+    JsonDocument doc;
+    doc["node_id"] = NODE_ID;
+    doc["armed"] = armed;
+    doc["timestamp"] = millis();
+
+    char buf[128];
+    serializeJson(doc, buf, sizeof(buf));
+    mqtt.publish(TOPIC_ARMED, buf, true);  // retained
+}
+
+void publishAlarm() {
+    JsonDocument doc;
+    doc["node_id"] = NODE_ID;
+    doc["event"] = "relay_activated";
+    doc["trigger_count"] = triggerCount;
+    doc["timestamp"] = millis();
+
+    char buf[256];
+    serializeJson(doc, buf, sizeof(buf));
+    mqtt.publish(TOPIC_ALARM, buf);
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Button handling
+// ════════════════════════════════════════════════════════════════════
+
+void checkButton() {
+    unsigned long now = millis();
+    if (now - lastButtonCheckMs < DEBOUNCE_MS) return;
+    lastButtonCheckMs = now;
+
+    bool currentState = digitalRead(PIN_BTN_ARM);
+    if (currentState == LOW && lastButtonState == HIGH) {
+        armed = !armed;
+        Serial.printf("[ARM] Button toggled, armed=%s\n", armed ? "true" : "false");
+        publishArmedState();
+
+        // Short beep to confirm
+        digitalWrite(PIN_BUZZER, HIGH);
+        delay(100);
+        digitalWrite(PIN_BUZZER, LOW);
+
+        if (!armed) {
+            deactivateRelay();
+        }
+    }
+    lastButtonState = currentState;
+}

--- a/apps/firmware/skywatch-hub/include/config.h
+++ b/apps/firmware/skywatch-hub/include/config.h
@@ -1,0 +1,58 @@
+#pragma once
+
+// ── Node identity ──────────────────────────────────────────────────
+#ifndef NODE_ID
+#define NODE_ID "hub-001"
+#endif
+
+// ── WiFi AP settings ───────────────────────────────────────────────
+#ifndef WIFI_AP_SSID
+#define WIFI_AP_SSID "SkyWatch-Hub"
+#endif
+#ifndef WIFI_AP_PASS
+#define WIFI_AP_PASS "phoenix2026"
+#endif
+#define WIFI_AP_CHANNEL   6
+#define WIFI_AP_MAX_CONN  4
+#define WIFI_AP_IP        "192.168.4.1"
+
+// ── MQTT broker (runs on this device) ──────────────────────────────
+#define MQTT_PORT 1883
+
+// ── MQTT topics to subscribe ───────────────────────────────────────
+#define TOPIC_DETECTION_ALL  "skywatch/+/detection"
+#define TOPIC_STATUS_ALL     "skywatch/+/status"
+#define TOPIC_ARMED_ALL      "skywatch/+/armed"
+#define TOPIC_ALARM_ALL      "alarm/+/activated"
+
+// ── I2C — PCA9685 servo driver ─────────────────────────────────────
+#define PIN_SDA           8
+#define PIN_SCL           9
+#define PCA9685_ADDR      0x40
+#define SERVO_FREQ_HZ     50    // Standard servo PWM frequency
+
+// ── Servo channels ─────────────────────────────────────────────────
+#define SERVO_CH_PAN      0     // PCA9685 channel 0 = yaw
+#define SERVO_CH_TILT     1     // PCA9685 channel 1 = pitch
+
+// Servo pulse widths (microseconds) for SG90
+#define SERVO_MIN_US      500   // 0°
+#define SERVO_MAX_US      2400  // 180°
+#define SERVO_CENTER_US   1450  // ~90° center
+
+// Angle limits
+#define PAN_MIN_DEG       0
+#define PAN_MAX_DEG       180
+#define PAN_CENTER_DEG    90
+#define TILT_MIN_DEG      30    // Don't tilt below 30° (mechanical limit)
+#define TILT_MAX_DEG      150
+#define TILT_CENTER_DEG   90
+
+// ── GPIO pins ──────────────────────────────────────────────────────
+#define PIN_LED_STATUS    2     // Blue LED — hub active
+#define PIN_LED_MQTT      3     // Green LED — blinks on MQTT message
+
+// ── Timing ─────────────────────────────────────────────────────────
+#define HEARTBEAT_INTERVAL_MS  30000
+#define LED_BLINK_MS           100    // MQTT activity LED flash duration
+#define SERVO_MOVE_STEP_MS     20     // Smooth servo movement interval

--- a/apps/firmware/skywatch-hub/include/config.h
+++ b/apps/firmware/skywatch-hub/include/config.h
@@ -52,7 +52,34 @@
 #define PIN_LED_STATUS    2     // Blue LED — hub active
 #define PIN_LED_MQTT      3     // Green LED — blinks on MQTT message
 
+// ── SPI — SX1276 LoRa module ──────────────────────────────────────
+#define LORA_ENABLED      true  // Set false if no LoRa module attached
+#define PIN_LORA_SCK      12    // SPI clock
+#define PIN_LORA_MISO     13    // SPI data out (from SX1276)
+#define PIN_LORA_MOSI     11    // SPI data in (to SX1276)
+#define PIN_LORA_CS       10    // Chip select (NSS)
+#define PIN_LORA_RST      14    // Reset
+#define PIN_LORA_DIO0     15    // Interrupt — RX done / TX done
+
+// LoRa radio parameters (868 MHz ISM band — South Africa / EU)
+#define LORA_FREQUENCY    868E6       // 868 MHz (use 915E6 for US/AU)
+#define LORA_BANDWIDTH    125E3       // 125 kHz (standard)
+#define LORA_SPREAD_FACTOR 9          // SF9: ~5km range, ~1.7kbps
+#define LORA_TX_POWER     17          // dBm (max 20 for SX1276)
+#define LORA_CODING_RATE  5           // 4/5 coding rate
+#define LORA_SYNC_WORD    0x34        // Private network sync word
+#define LORA_PREAMBLE_LEN 8           // Standard preamble
+
+// LoRa message types (single-byte header)
+#define LORA_MSG_ALERT    0x01  // Detection alert (hub → remote)
+#define LORA_MSG_ARM      0x02  // Arm/disarm command (hub → remote)
+#define LORA_MSG_HEARTBEAT 0x03 // Heartbeat (bidirectional)
+#define LORA_MSG_ACK      0x04  // Acknowledgment (remote → hub)
+#define LORA_MSG_STATUS   0x05  // Status request/response
+
 // ── Timing ─────────────────────────────────────────────────────────
 #define HEARTBEAT_INTERVAL_MS  30000
 #define LED_BLINK_MS           100    // MQTT activity LED flash duration
 #define SERVO_MOVE_STEP_MS     20     // Smooth servo movement interval
+#define LORA_HEARTBEAT_MS      60000  // LoRa heartbeat every 60s (airtime budget)
+#define LORA_TX_TIMEOUT_MS     2000   // Max time to wait for TX complete

--- a/apps/firmware/skywatch-hub/platformio.ini
+++ b/apps/firmware/skywatch-hub/platformio.ini
@@ -1,0 +1,16 @@
+[env:esp32s3]
+platform = espressif32
+board = esp32-s3-devkitc-1
+framework = arduino
+monitor_speed = 115200
+upload_speed = 921600
+lib_deps =
+    knolleary/PubSubClient@^2.8
+    bblanchon/ArduinoJson@^7.0
+    adafruit/Adafruit PWM Servo Driver Library@^3.0
+    hsaturn/TinyMqtt@^0.9
+build_flags =
+    -DNODE_ID=\"hub-001\"
+    -DWIFI_AP_SSID=\"SkyWatch-Hub\"
+    -DWIFI_AP_PASS=\"phoenix2026\"
+    -DARDUINO_USB_CDC_ON_BOOT=1

--- a/apps/firmware/skywatch-hub/platformio.ini
+++ b/apps/firmware/skywatch-hub/platformio.ini
@@ -9,6 +9,7 @@ lib_deps =
     bblanchon/ArduinoJson@^7.0
     adafruit/Adafruit PWM Servo Driver Library@^3.0
     hsaturn/TinyMqtt@^0.9
+    sandeepmistry/LoRa@^0.8
 build_flags =
     -DNODE_ID=\"hub-001\"
     -DWIFI_AP_SSID=\"SkyWatch-Hub\"

--- a/apps/firmware/skywatch-hub/src/main.cpp
+++ b/apps/firmware/skywatch-hub/src/main.cpp
@@ -1,0 +1,260 @@
+/**
+ * SkyWatch Hub — ESP32-S3 Central Coordinator
+ *
+ * Phase 1 firmware for the hub node. Runs:
+ *   1. WiFi Access Point (other nodes connect here)
+ *   2. MQTT broker (TinyMqtt, lightweight embedded broker)
+ *   3. PCA9685 servo controller for pan/tilt turret
+ *   4. Detection event aggregation and logging
+ *
+ * Hardware: ESP32-S3, PCA9685, 2x SG90 servos, status LEDs.
+ */
+
+#include <Arduino.h>
+#include <WiFi.h>
+#include <Wire.h>
+#include <TinyMqtt.h>
+#include <Adafruit_PWMServoDriver.h>
+#include <ArduinoJson.h>
+#include "config.h"
+
+// ── Globals ────────────────────────────────────────────────────────
+MqttBroker broker(MQTT_PORT);
+MqttClient hubClient(&broker);
+Adafruit_PWMServoDriver pwm = Adafruit_PWMServoDriver(PCA9685_ADDR);
+
+int currentPan = PAN_CENTER_DEG;
+int currentTilt = TILT_CENTER_DEG;
+int targetPan = PAN_CENTER_DEG;
+int targetTilt = TILT_CENTER_DEG;
+
+unsigned long lastHeartbeatMs = 0;
+unsigned long lastMqttLedMs = 0;
+unsigned long lastServoStepMs = 0;
+uint32_t totalDetections = 0;
+uint32_t connectedClients = 0;
+
+// ── Forward declarations ───────────────────────────────────────────
+void setupWifiAP();
+void setupMqttBroker();
+void setupServos();
+void setupPins();
+void onHubMessage(const MqttClient *source, const Topic &topic, const char *payload, size_t length);
+void handleDetection(const char *payload, size_t length);
+void setServoAngle(uint8_t channel, int angle);
+int angleToPulse(int angle);
+void updateServos();
+void publishHeartbeat();
+void blinkMqttLed();
+
+// ════════════════════════════════════════════════════════════════════
+// Setup
+// ════════════════════════════════════════════════════════════════════
+
+void setup() {
+    Serial.begin(115200);
+    Serial.println("\n[SkyWatch Hub] Booting...");
+    Serial.printf("[SkyWatch Hub] Node ID: %s\n", NODE_ID);
+
+    setupPins();
+    setupWifiAP();
+    setupMqttBroker();
+    setupServos();
+
+    Serial.println("[SkyWatch Hub] Ready. Waiting for nodes...");
+    Serial.printf("[SkyWatch Hub] WiFi AP: %s\n", WIFI_AP_SSID);
+    Serial.printf("[SkyWatch Hub] MQTT broker on port %d\n", MQTT_PORT);
+    digitalWrite(PIN_LED_STATUS, HIGH);
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Main loop
+// ════════════════════════════════════════════════════════════════════
+
+void loop() {
+    unsigned long now = millis();
+
+    broker.loop();
+    hubClient.loop();
+
+    // Smooth servo movement
+    if (now - lastServoStepMs > SERVO_MOVE_STEP_MS) {
+        lastServoStepMs = now;
+        updateServos();
+    }
+
+    // Heartbeat
+    if (now - lastHeartbeatMs > HEARTBEAT_INTERVAL_MS) {
+        lastHeartbeatMs = now;
+        publishHeartbeat();
+    }
+
+    // MQTT activity LED auto-off
+    if (lastMqttLedMs > 0 && now - lastMqttLedMs > LED_BLINK_MS) {
+        digitalWrite(PIN_LED_MQTT, LOW);
+        lastMqttLedMs = 0;
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════
+// WiFi Access Point
+// ════════════════════════════════════════════════════════════════════
+
+void setupWifiAP() {
+    WiFi.mode(WIFI_AP);
+    WiFi.softAP(WIFI_AP_SSID, WIFI_AP_PASS, WIFI_AP_CHANNEL, 0, WIFI_AP_MAX_CONN);
+
+    IPAddress ip = WiFi.softAPIP();
+    Serial.printf("[WiFi AP] Started. IP: %s\n", ip.toString().c_str());
+}
+
+// ════════════════════════════════════════════════════════════════════
+// MQTT Broker + Hub Client
+// ════════════════════════════════════════════════════════════════════
+
+void setupMqttBroker() {
+    broker.begin();
+    Serial.printf("[MQTT] Broker started on port %d\n", MQTT_PORT);
+
+    hubClient.setCallback(onHubMessage);
+    hubClient.subscribe(TOPIC_DETECTION_ALL);
+    hubClient.subscribe(TOPIC_STATUS_ALL);
+    hubClient.subscribe(TOPIC_ARMED_ALL);
+    hubClient.subscribe(TOPIC_ALARM_ALL);
+    Serial.println("[MQTT] Hub client subscribed to all topics.");
+}
+
+void onHubMessage(const MqttClient *source, const Topic &topic, const char *payload, size_t length) {
+    blinkMqttLed();
+
+    String topicStr = topic.c_str();
+    Serial.printf("[MQTT] %s: %.*s\n", topicStr.c_str(), (int)length, payload);
+
+    // Handle detection events — extract bearing and aim turret
+    if (topicStr.indexOf("/detection") > 0) {
+        handleDetection(payload, length);
+    }
+}
+
+void handleDetection(const char *payload, size_t length) {
+    totalDetections++;
+
+    JsonDocument doc;
+    char buf[512];
+    size_t copyLen = min((size_t)511, length);
+    memcpy(buf, payload, copyLen);
+    buf[copyLen] = '\0';
+
+    if (deserializeJson(doc, buf) != DeserializationError::Ok) {
+        Serial.println("[DETECT] Failed to parse detection JSON");
+        return;
+    }
+
+    Serial.printf("[DETECT] Detection #%u from node %s\n",
+                  totalDetections,
+                  doc["node_id"] | "unknown");
+
+    // In Phase 1 with single camera, we sweep the turret to center.
+    // Phase 2 adds bearing calculation from detection bounding box.
+    // For now, trigger a simple scan pattern on detection.
+    targetPan = random(PAN_MIN_DEG + 20, PAN_MAX_DEG - 20);
+    targetTilt = random(TILT_MIN_DEG + 10, TILT_MAX_DEG - 10);
+
+    // Forward trigger command to response relay
+    JsonDocument cmdDoc;
+    cmdDoc["command"] = "trigger";
+    cmdDoc["source"] = NODE_ID;
+    cmdDoc["detection_count"] = totalDetections;
+    cmdDoc["timestamp"] = millis();
+
+    char cmdBuf[256];
+    serializeJson(cmdDoc, cmdBuf, sizeof(cmdBuf));
+
+    // Publish to all relay nodes (wildcard not supported for publish,
+    // so we target a specific node ID for now)
+    hubClient.publish("command/relay-001/trigger", cmdBuf);
+}
+
+// ════════════════════════════════════════════════════════════════════
+// PCA9685 Servo Control
+// ════════════════════════════════════════════════════════════════════
+
+void setupServos() {
+    Wire.begin(PIN_SDA, PIN_SCL);
+    pwm.begin();
+    pwm.setOscillatorFrequency(27000000);
+    pwm.setPWMFreq(SERVO_FREQ_HZ);
+
+    // Center both servos
+    setServoAngle(SERVO_CH_PAN, PAN_CENTER_DEG);
+    setServoAngle(SERVO_CH_TILT, TILT_CENTER_DEG);
+    Serial.println("[Servo] PCA9685 initialized, servos centered.");
+}
+
+void setServoAngle(uint8_t channel, int angle) {
+    int pulse = angleToPulse(angle);
+    // Convert microseconds to PCA9685 tick count (4096 ticks per 20ms period)
+    int tickCount = (int)((float)pulse / 20000.0f * 4096.0f);
+    pwm.setPWM(channel, 0, tickCount);
+}
+
+int angleToPulse(int angle) {
+    // Map 0-180° to SERVO_MIN_US - SERVO_MAX_US
+    return map(angle, 0, 180, SERVO_MIN_US, SERVO_MAX_US);
+}
+
+void updateServos() {
+    // Smooth step toward target (1° per step)
+    bool moved = false;
+
+    if (currentPan < targetPan) { currentPan++; moved = true; }
+    else if (currentPan > targetPan) { currentPan--; moved = true; }
+
+    if (currentTilt < targetTilt) { currentTilt++; moved = true; }
+    else if (currentTilt > targetTilt) { currentTilt--; moved = true; }
+
+    if (moved) {
+        setServoAngle(SERVO_CH_PAN, currentPan);
+        setServoAngle(SERVO_CH_TILT, currentTilt);
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Heartbeat
+// ════════════════════════════════════════════════════════════════════
+
+void publishHeartbeat() {
+    JsonDocument doc;
+    doc["node_id"] = NODE_ID;
+    doc["type"] = "heartbeat";
+    doc["role"] = "hub";
+    doc["uptime_ms"] = millis();
+    doc["total_detections"] = totalDetections;
+    doc["connected_clients"] = WiFi.softAPgetStationNum();
+    doc["pan_deg"] = currentPan;
+    doc["tilt_deg"] = currentTilt;
+    doc["free_heap"] = ESP.getFreeHeap();
+
+    char buf[256];
+    serializeJson(doc, buf, sizeof(buf));
+    hubClient.publish("skywatch/hub-001/status", buf);
+
+    Serial.printf("[HUB] Heartbeat: %u detections, %d clients\n",
+                  totalDetections, WiFi.softAPgetStationNum());
+}
+
+// ════════════════════════════════════════════════════════════════════
+// GPIO / LEDs
+// ════════════════════════════════════════════════════════════════════
+
+void setupPins() {
+    pinMode(PIN_LED_STATUS, OUTPUT);
+    pinMode(PIN_LED_MQTT, OUTPUT);
+    digitalWrite(PIN_LED_STATUS, LOW);
+    digitalWrite(PIN_LED_MQTT, LOW);
+}
+
+void blinkMqttLed() {
+    digitalWrite(PIN_LED_MQTT, HIGH);
+    lastMqttLedMs = millis();
+}

--- a/apps/firmware/skywatch-hub/src/main.cpp
+++ b/apps/firmware/skywatch-hub/src/main.cpp
@@ -6,16 +6,19 @@
  *   2. MQTT broker (TinyMqtt, lightweight embedded broker)
  *   3. PCA9685 servo controller for pan/tilt turret
  *   4. Detection event aggregation and logging
+ *   5. LoRa gateway — bridges MQTT alerts to long-range radio (SX1276)
  *
- * Hardware: ESP32-S3, PCA9685, 2x SG90 servos, status LEDs.
+ * Hardware: ESP32-S3, PCA9685, 2x SG90 servos, SX1276 LoRa, status LEDs.
  */
 
 #include <Arduino.h>
 #include <WiFi.h>
 #include <Wire.h>
+#include <SPI.h>
 #include <TinyMqtt.h>
 #include <Adafruit_PWMServoDriver.h>
 #include <ArduinoJson.h>
+#include <LoRa.h>
 #include "config.h"
 
 // ── Globals ────────────────────────────────────────────────────────
@@ -31,14 +34,19 @@ int targetTilt = TILT_CENTER_DEG;
 unsigned long lastHeartbeatMs = 0;
 unsigned long lastMqttLedMs = 0;
 unsigned long lastServoStepMs = 0;
+unsigned long lastLoraHeartbeatMs = 0;
 uint32_t totalDetections = 0;
 uint32_t connectedClients = 0;
+bool loraReady = false;
+uint32_t loraTxCount = 0;
+uint32_t loraRxCount = 0;
 
 // ── Forward declarations ───────────────────────────────────────────
 void setupWifiAP();
 void setupMqttBroker();
 void setupServos();
 void setupPins();
+void setupLora();
 void onHubMessage(const MqttClient *source, const Topic &topic, const char *payload, size_t length);
 void handleDetection(const char *payload, size_t length);
 void setServoAngle(uint8_t channel, int angle);
@@ -46,6 +54,11 @@ int angleToPulse(int angle);
 void updateServos();
 void publishHeartbeat();
 void blinkMqttLed();
+void loraSendAlert(uint32_t detectionId);
+void loraSendArm(bool armed);
+void loraSendHeartbeat();
+void loraReceive();
+void onLoraReceive(int packetSize);
 
 // ════════════════════════════════════════════════════════════════════
 // Setup
@@ -60,10 +73,14 @@ void setup() {
     setupWifiAP();
     setupMqttBroker();
     setupServos();
+    setupLora();
 
     Serial.println("[SkyWatch Hub] Ready. Waiting for nodes...");
     Serial.printf("[SkyWatch Hub] WiFi AP: %s\n", WIFI_AP_SSID);
     Serial.printf("[SkyWatch Hub] MQTT broker on port %d\n", MQTT_PORT);
+    if (loraReady) {
+        Serial.printf("[SkyWatch Hub] LoRa gateway on %.0f MHz\n", LORA_FREQUENCY / 1E6);
+    }
     digitalWrite(PIN_LED_STATUS, HIGH);
 }
 
@@ -87,6 +104,15 @@ void loop() {
     if (now - lastHeartbeatMs > HEARTBEAT_INTERVAL_MS) {
         lastHeartbeatMs = now;
         publishHeartbeat();
+    }
+
+    // LoRa receive check + periodic heartbeat
+    if (loraReady) {
+        loraReceive();
+        if (now - lastLoraHeartbeatMs > LORA_HEARTBEAT_MS) {
+            lastLoraHeartbeatMs = now;
+            loraSendHeartbeat();
+        }
     }
 
     // MQTT activity LED auto-off
@@ -173,6 +199,11 @@ void handleDetection(const char *payload, size_t length) {
     // Publish to all relay nodes (wildcard not supported for publish,
     // so we target a specific node ID for now)
     hubClient.publish("command/relay-001/trigger", cmdBuf);
+
+    // Bridge alert to LoRa for remote nodes beyond WiFi range
+    if (loraReady) {
+        loraSendAlert(totalDetections);
+    }
 }
 
 // ════════════════════════════════════════════════════════════════════
@@ -234,13 +265,159 @@ void publishHeartbeat() {
     doc["pan_deg"] = currentPan;
     doc["tilt_deg"] = currentTilt;
     doc["free_heap"] = ESP.getFreeHeap();
+    doc["lora_ready"] = loraReady;
+    doc["lora_tx"] = loraTxCount;
+    doc["lora_rx"] = loraRxCount;
 
-    char buf[256];
+    char buf[384];
     serializeJson(doc, buf, sizeof(buf));
     hubClient.publish("skywatch/hub-001/status", buf);
 
-    Serial.printf("[HUB] Heartbeat: %u detections, %d clients\n",
-                  totalDetections, WiFi.softAPgetStationNum());
+    Serial.printf("[HUB] Heartbeat: %u detections, %d clients, LoRa TX:%u RX:%u\n",
+                  totalDetections, WiFi.softAPgetStationNum(), loraTxCount, loraRxCount);
+}
+
+// ════════════════════════════════════════════════════════════════════
+// LoRa Gateway (SX1276 868 MHz)
+// ════════════════════════════════════════════════════════════════════
+
+void setupLora() {
+    if (!LORA_ENABLED) {
+        Serial.println("[LoRa] Disabled in config.");
+        return;
+    }
+
+    // Configure SPI pins for SX1276
+    SPI.begin(PIN_LORA_SCK, PIN_LORA_MISO, PIN_LORA_MOSI, PIN_LORA_CS);
+    LoRa.setPins(PIN_LORA_CS, PIN_LORA_RST, PIN_LORA_DIO0);
+
+    if (!LoRa.begin(LORA_FREQUENCY)) {
+        Serial.println("[LoRa] Init FAILED — check wiring / module.");
+        loraReady = false;
+        return;
+    }
+
+    // Configure radio parameters
+    LoRa.setSpreadingFactor(LORA_SPREAD_FACTOR);
+    LoRa.setSignalBandwidth(LORA_BANDWIDTH);
+    LoRa.setCodingRate4(LORA_CODING_RATE);
+    LoRa.setTxPower(LORA_TX_POWER);
+    LoRa.setSyncWord(LORA_SYNC_WORD);
+    LoRa.setPreambleLength(LORA_PREAMBLE_LEN);
+    LoRa.enableCrc();
+
+    loraReady = true;
+    Serial.printf("[LoRa] Ready. Freq=%.0fMHz SF=%d BW=%.0fkHz TxPwr=%ddBm\n",
+                  LORA_FREQUENCY / 1E6, LORA_SPREAD_FACTOR,
+                  LORA_BANDWIDTH / 1E3, LORA_TX_POWER);
+}
+
+/**
+ * Send detection alert over LoRa.
+ * Compact binary packet: [type(1)] [detection_id(4)] [pan(2)] [tilt(2)] [timestamp(4)]
+ * Total: 13 bytes — minimal airtime.
+ */
+void loraSendAlert(uint32_t detectionId) {
+    LoRa.beginPacket();
+    LoRa.write(LORA_MSG_ALERT);
+    LoRa.write((uint8_t *)&detectionId, 4);
+    int16_t pan = (int16_t)currentPan;
+    int16_t tilt = (int16_t)currentTilt;
+    LoRa.write((uint8_t *)&pan, 2);
+    LoRa.write((uint8_t *)&tilt, 2);
+    uint32_t ts = millis();
+    LoRa.write((uint8_t *)&ts, 4);
+    LoRa.endPacket(true);  // async (non-blocking)
+
+    loraTxCount++;
+    Serial.printf("[LoRa TX] Alert #%u pan=%d tilt=%d\n", detectionId, pan, tilt);
+}
+
+/**
+ * Send arm/disarm command over LoRa.
+ * Packet: [type(1)] [armed(1)]
+ */
+void loraSendArm(bool armed) {
+    LoRa.beginPacket();
+    LoRa.write(LORA_MSG_ARM);
+    LoRa.write(armed ? 1 : 0);
+    LoRa.endPacket(true);
+
+    loraTxCount++;
+    Serial.printf("[LoRa TX] Arm=%s\n", armed ? "true" : "false");
+}
+
+/**
+ * Send heartbeat over LoRa (low-frequency, saves airtime).
+ * Packet: [type(1)] [uptime(4)] [detections(4)] [clients(1)]
+ */
+void loraSendHeartbeat() {
+    LoRa.beginPacket();
+    LoRa.write(LORA_MSG_HEARTBEAT);
+    uint32_t uptime = millis();
+    LoRa.write((uint8_t *)&uptime, 4);
+    LoRa.write((uint8_t *)&totalDetections, 4);
+    uint8_t clients = (uint8_t)WiFi.softAPgetStationNum();
+    LoRa.write(clients);
+    LoRa.endPacket(true);
+
+    loraTxCount++;
+    Serial.println("[LoRa TX] Heartbeat");
+}
+
+/**
+ * Check for incoming LoRa packets from remote nodes.
+ * Remote nodes send ACKs, status reports, and their own detections.
+ */
+void loraReceive() {
+    int packetSize = LoRa.parsePacket();
+    if (packetSize == 0) return;
+
+    loraRxCount++;
+    int rssi = LoRa.packetRssi();
+    float snr = LoRa.packetSnr();
+
+    uint8_t msgType = LoRa.read();
+    Serial.printf("[LoRa RX] Type=0x%02X Size=%d RSSI=%d SNR=%.1f\n",
+                  msgType, packetSize, rssi, snr);
+
+    switch (msgType) {
+        case LORA_MSG_ACK: {
+            uint32_t ackedId;
+            if (LoRa.available() >= 4) {
+                LoRa.readBytes((uint8_t *)&ackedId, 4);
+                Serial.printf("[LoRa RX] ACK for detection #%u\n", ackedId);
+            }
+            break;
+        }
+        case LORA_MSG_HEARTBEAT: {
+            // Remote node heartbeat — publish to MQTT so local nodes see it
+            JsonDocument doc;
+            doc["source"] = "lora_remote";
+            doc["rssi"] = rssi;
+            doc["snr"] = snr;
+            doc["type"] = "heartbeat";
+            if (LoRa.available() >= 4) {
+                uint32_t remoteUptime;
+                LoRa.readBytes((uint8_t *)&remoteUptime, 4);
+                doc["remote_uptime_ms"] = remoteUptime;
+            }
+            char buf[256];
+            serializeJson(doc, buf, sizeof(buf));
+            hubClient.publish("skywatch/lora-remote/status", buf);
+            break;
+        }
+        case LORA_MSG_STATUS: {
+            // Status response — log RSSI/SNR for link quality monitoring
+            Serial.printf("[LoRa RX] Status from remote. Link: RSSI=%d SNR=%.1f\n", rssi, snr);
+            break;
+        }
+        default:
+            Serial.printf("[LoRa RX] Unknown message type 0x%02X\n", msgType);
+            break;
+    }
+
+    blinkMqttLed();  // Reuse MQTT LED to indicate LoRa activity too
 }
 
 // ════════════════════════════════════════════════════════════════════

--- a/apps/firmware/skywatch-nano/include/config.h
+++ b/apps/firmware/skywatch-nano/include/config.h
@@ -1,0 +1,53 @@
+#pragma once
+
+// ── Node identity ──────────────────────────────────────────────────
+#ifndef NODE_ID
+#define NODE_ID "nano-001"
+#endif
+
+// ── WiFi (connects to Hub AP) ──────────────────────────────────────
+#ifndef WIFI_SSID
+#define WIFI_SSID "SkyWatch-Hub"
+#endif
+#ifndef WIFI_PASS
+#define WIFI_PASS "phoenix2026"
+#endif
+
+// ── MQTT ───────────────────────────────────────────────────────────
+#ifndef MQTT_BROKER
+#define MQTT_BROKER "192.168.4.1"
+#endif
+#define MQTT_PORT 1883
+
+// Topic templates — node_id substituted at runtime
+#define TOPIC_DETECTION "skywatch/" NODE_ID "/detection"
+#define TOPIC_STATUS    "skywatch/" NODE_ID "/status"
+#define TOPIC_ARMED     "skywatch/" NODE_ID "/armed"
+#define TOPIC_CMD_ARM   "command/" NODE_ID "/arm"
+#define TOPIC_CMD_CFG   "command/" NODE_ID "/config"
+
+// ── GPIO pins (ESP32-CAM, no SD card) ──────────────────────────────
+#define PIN_BUZZER       12   // NPN transistor → active buzzer
+#define PIN_LED_BEACON   13   // 220Ω → alarm LED
+#define PIN_BTN_ARM      14   // Pushbutton (active LOW, 10kΩ pull-up)
+#define PIN_LED_STATUS   15   // 220Ω → status LED
+#define PIN_FLASH_LED     4   // Built-in flash (do not reassign)
+
+// ── Camera settings ────────────────────────────────────────────────
+#define CAM_FRAME_SIZE   FRAMESIZE_QVGA   // 320x240
+#define CAM_JPEG_QUALITY 12                // 0-63 (lower = better)
+#define CAM_FB_COUNT     2                 // Frame buffer count (PSRAM)
+
+// ── Detection settings ─────────────────────────────────────────────
+#define DETECT_THRESHOLD     30     // Frame-diff pixel threshold (0-255)
+#define DETECT_MIN_AREA      500    // Minimum changed pixels to trigger
+#define DETECT_COOLDOWN_MS   3000   // Min ms between detections
+
+// ── Timing ─────────────────────────────────────────────────────────
+#define HEARTBEAT_INTERVAL_MS  30000  // Status heartbeat every 30s
+#define DEBOUNCE_MS            200    // Button debounce
+#define MQTT_RECONNECT_MS      5000   // MQTT reconnect backoff
+#define WIFI_RECONNECT_MS      10000  // WiFi reconnect backoff
+
+// ── MJPEG stream ───────────────────────────────────────────────────
+#define STREAM_PORT 81   // HTTP MJPEG stream on :81

--- a/apps/firmware/skywatch-nano/platformio.ini
+++ b/apps/firmware/skywatch-nano/platformio.ini
@@ -1,0 +1,15 @@
+[env:esp32cam]
+platform = espressif32
+board = esp32cam
+framework = arduino
+monitor_speed = 115200
+upload_speed = 921600
+lib_deps =
+    knolleary/PubSubClient@^2.8
+    bblanchon/ArduinoJson@^7.0
+build_flags =
+    -DBOARD_HAS_PSRAM
+    -DNODE_ID=\"nano-001\"
+    -DWIFI_SSID=\"SkyWatch-Hub\"
+    -DWIFI_PASS=\"phoenix2026\"
+    -DMQTT_BROKER=\"192.168.4.1\"

--- a/apps/firmware/skywatch-nano/src/main.cpp
+++ b/apps/firmware/skywatch-nano/src/main.cpp
@@ -1,0 +1,431 @@
+/**
+ * SkyWatch Nano — ESP32-CAM Detection Node
+ *
+ * Phase 1 firmware for camera-based motion detection.
+ * Captures frames, runs simple frame-differencing, publishes
+ * detection events to MQTT, and serves an MJPEG stream.
+ *
+ * Hardware: ESP32-CAM (OV2640), buzzer, LEDs, pushbutton.
+ * Network:  Connects to SkyWatch Hub WiFi AP, publishes via MQTT.
+ */
+
+#include <Arduino.h>
+#include <WiFi.h>
+#include <PubSubClient.h>
+#include <ArduinoJson.h>
+#include "esp_camera.h"
+#include "esp_http_server.h"
+#include "config.h"
+
+// ── Camera pin definitions (AI-Thinker ESP32-CAM) ──────────────────
+#define PWDN_GPIO_NUM     32
+#define RESET_GPIO_NUM    -1
+#define XCLK_GPIO_NUM      0
+#define SIOD_GPIO_NUM     26
+#define SIOC_GPIO_NUM     27
+#define Y9_GPIO_NUM       35
+#define Y8_GPIO_NUM       34
+#define Y7_GPIO_NUM       39
+#define Y6_GPIO_NUM       36
+#define Y5_GPIO_NUM       21
+#define Y4_GPIO_NUM       19
+#define Y3_GPIO_NUM       18
+#define Y2_GPIO_NUM        5
+#define VSYNC_GPIO_NUM    25
+#define HREF_GPIO_NUM     23
+#define PCLK_GPIO_NUM     22
+
+// ── Globals ────────────────────────────────────────────────────────
+WiFiClient wifiClient;
+PubSubClient mqtt(wifiClient);
+httpd_handle_t streamServer = NULL;
+
+bool armed = true;
+bool lastButtonState = HIGH;
+unsigned long lastDetectionMs = 0;
+unsigned long lastHeartbeatMs = 0;
+unsigned long lastMqttAttemptMs = 0;
+unsigned long lastWifiAttemptMs = 0;
+unsigned long lastButtonCheckMs = 0;
+uint32_t detectionCount = 0;
+uint8_t *prevFrame = NULL;
+size_t prevFrameLen = 0;
+
+// ── Forward declarations ───────────────────────────────────────────
+void setupCamera();
+void setupPins();
+void setupWifi();
+void setupMqtt();
+void setupStream();
+void onMqttMessage(char *topic, byte *payload, unsigned int length);
+void publishDetection(uint32_t changedPixels, size_t frameSize);
+void publishHeartbeat();
+void publishArmedState();
+void checkButton();
+void triggerAlarm(bool on);
+bool detectMotion(camera_fb_t *fb);
+esp_err_t streamHandler(httpd_req_t *req);
+
+// ════════════════════════════════════════════════════════════════════
+// Setup
+// ════════════════════════════════════════════════════════════════════
+
+void setup() {
+    Serial.begin(115200);
+    Serial.println("\n[SkyWatch Nano] Booting...");
+    Serial.printf("[SkyWatch Nano] Node ID: %s\n", NODE_ID);
+
+    setupPins();
+    setupCamera();
+    setupWifi();
+    setupMqtt();
+    setupStream();
+
+    // Allocate previous frame buffer for motion detection
+    prevFrame = (uint8_t *)ps_malloc(320 * 240);
+    if (!prevFrame) {
+        Serial.println("[ERROR] Failed to allocate prevFrame in PSRAM");
+    }
+
+    Serial.println("[SkyWatch Nano] Ready.");
+    digitalWrite(PIN_LED_STATUS, HIGH);
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Main loop
+// ════════════════════════════════════════════════════════════════════
+
+void loop() {
+    unsigned long now = millis();
+
+    // WiFi reconnect
+    if (WiFi.status() != WL_CONNECTED) {
+        digitalWrite(PIN_LED_STATUS, LOW);
+        if (now - lastWifiAttemptMs > WIFI_RECONNECT_MS) {
+            lastWifiAttemptMs = now;
+            Serial.println("[WiFi] Reconnecting...");
+            WiFi.begin(WIFI_SSID, WIFI_PASS);
+        }
+        return;
+    }
+
+    // MQTT reconnect
+    if (!mqtt.connected()) {
+        if (now - lastMqttAttemptMs > MQTT_RECONNECT_MS) {
+            lastMqttAttemptMs = now;
+            Serial.println("[MQTT] Connecting...");
+            if (mqtt.connect(NODE_ID)) {
+                Serial.println("[MQTT] Connected.");
+                mqtt.subscribe(TOPIC_CMD_ARM);
+                mqtt.subscribe(TOPIC_CMD_CFG);
+                publishArmedState();
+                publishHeartbeat();
+            }
+        }
+    }
+    mqtt.loop();
+
+    // Check arm/disarm button
+    checkButton();
+
+    // Capture and detect
+    camera_fb_t *fb = esp_camera_fb_get();
+    if (fb) {
+        if (armed && detectMotion(fb)) {
+            if (now - lastDetectionMs > DETECT_COOLDOWN_MS) {
+                lastDetectionMs = now;
+                detectionCount++;
+                publishDetection(0, fb->len);
+                triggerAlarm(true);
+                delay(500);
+                triggerAlarm(false);
+            }
+        }
+        esp_camera_fb_return(fb);
+    }
+
+    // Heartbeat
+    if (now - lastHeartbeatMs > HEARTBEAT_INTERVAL_MS) {
+        lastHeartbeatMs = now;
+        publishHeartbeat();
+    }
+
+    // Status LED blink when armed
+    if (armed) {
+        digitalWrite(PIN_LED_STATUS, (now / 500) % 2);
+    } else {
+        digitalWrite(PIN_LED_STATUS, HIGH);
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Camera setup
+// ════════════════════════════════════════════════════════════════════
+
+void setupCamera() {
+    camera_config_t config;
+    config.ledc_channel = LEDC_CHANNEL_0;
+    config.ledc_timer = LEDC_TIMER_0;
+    config.pin_d0 = Y2_GPIO_NUM;
+    config.pin_d1 = Y3_GPIO_NUM;
+    config.pin_d2 = Y4_GPIO_NUM;
+    config.pin_d3 = Y5_GPIO_NUM;
+    config.pin_d4 = Y6_GPIO_NUM;
+    config.pin_d5 = Y7_GPIO_NUM;
+    config.pin_d6 = Y8_GPIO_NUM;
+    config.pin_d7 = Y9_GPIO_NUM;
+    config.pin_xclk = XCLK_GPIO_NUM;
+    config.pin_pclk = PCLK_GPIO_NUM;
+    config.pin_vsync = VSYNC_GPIO_NUM;
+    config.pin_href = HREF_GPIO_NUM;
+    config.pin_sccb_sda = SIOD_GPIO_NUM;
+    config.pin_sccb_scl = SIOC_GPIO_NUM;
+    config.pin_pwdn = PWDN_GPIO_NUM;
+    config.pin_reset = RESET_GPIO_NUM;
+    config.xclk_freq_hz = 20000000;
+    config.pixel_format = PIXFORMAT_GRAYSCALE;
+    config.frame_size = FRAMESIZE_QVGA;
+    config.jpeg_quality = CAM_JPEG_QUALITY;
+    config.fb_count = CAM_FB_COUNT;
+    config.grab_mode = CAMERA_GRAB_LATEST;
+
+    if (psramFound()) {
+        config.fb_location = CAMERA_FB_IN_PSRAM;
+        Serial.println("[Camera] PSRAM found, using PSRAM frame buffers.");
+    } else {
+        config.fb_location = CAMERA_FB_IN_DRAM;
+        config.fb_count = 1;
+        Serial.println("[Camera] No PSRAM, using DRAM (limited).");
+    }
+
+    esp_err_t err = esp_camera_init(&config);
+    if (err != ESP_OK) {
+        Serial.printf("[Camera] Init failed: 0x%x\n", err);
+        return;
+    }
+    Serial.println("[Camera] Initialized OK.");
+}
+
+// ════════════════════════════════════════════════════════════════════
+// GPIO setup
+// ════════════════════════════════════════════════════════════════════
+
+void setupPins() {
+    pinMode(PIN_BUZZER, OUTPUT);
+    pinMode(PIN_LED_BEACON, OUTPUT);
+    pinMode(PIN_LED_STATUS, OUTPUT);
+    pinMode(PIN_BTN_ARM, INPUT_PULLUP);
+
+    digitalWrite(PIN_BUZZER, LOW);
+    digitalWrite(PIN_LED_BEACON, LOW);
+    digitalWrite(PIN_LED_STATUS, LOW);
+}
+
+// ════════════════════════════════════════════════════════════════════
+// WiFi
+// ════════════════════════════════════════════════════════════════════
+
+void setupWifi() {
+    Serial.printf("[WiFi] Connecting to %s\n", WIFI_SSID);
+    WiFi.mode(WIFI_STA);
+    WiFi.begin(WIFI_SSID, WIFI_PASS);
+
+    int attempts = 0;
+    while (WiFi.status() != WL_CONNECTED && attempts < 20) {
+        delay(500);
+        Serial.print(".");
+        attempts++;
+    }
+
+    if (WiFi.status() == WL_CONNECTED) {
+        Serial.printf("\n[WiFi] Connected. IP: %s\n", WiFi.localIP().toString().c_str());
+    } else {
+        Serial.println("\n[WiFi] Failed to connect. Will retry in loop.");
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════
+// MQTT
+// ════════════════════════════════════════════════════════════════════
+
+void setupMqtt() {
+    mqtt.setServer(MQTT_BROKER, MQTT_PORT);
+    mqtt.setCallback(onMqttMessage);
+    mqtt.setBufferSize(1024);
+}
+
+void onMqttMessage(char *topic, byte *payload, unsigned int length) {
+    char msg[256];
+    size_t copyLen = min((unsigned int)255, length);
+    memcpy(msg, payload, copyLen);
+    msg[copyLen] = '\0';
+
+    Serial.printf("[MQTT] Received on %s: %s\n", topic, msg);
+
+    if (strcmp(topic, TOPIC_CMD_ARM) == 0) {
+        JsonDocument doc;
+        if (deserializeJson(doc, msg) == DeserializationError::Ok) {
+            if (doc.containsKey("armed")) {
+                armed = doc["armed"].as<bool>();
+                Serial.printf("[ARM] Remote set armed=%s\n", armed ? "true" : "false");
+                publishArmedState();
+                if (!armed) {
+                    triggerAlarm(false);
+                    digitalWrite(PIN_LED_BEACON, LOW);
+                }
+            }
+        }
+    }
+}
+
+void publishDetection(uint32_t changedPixels, size_t frameSize) {
+    JsonDocument doc;
+    doc["event"] = "motion_detected";
+    doc["node_id"] = NODE_ID;
+    doc["timestamp"] = millis();
+    doc["detection_count"] = detectionCount;
+    doc["changed_pixels"] = changedPixels;
+    doc["frame_bytes"] = frameSize;
+    doc["armed"] = armed;
+
+    char buf[512];
+    serializeJson(doc, buf, sizeof(buf));
+    mqtt.publish(TOPIC_DETECTION, buf);
+    Serial.printf("[DETECT] #%u published\n", detectionCount);
+}
+
+void publishHeartbeat() {
+    JsonDocument doc;
+    doc["node_id"] = NODE_ID;
+    doc["type"] = "heartbeat";
+    doc["uptime_ms"] = millis();
+    doc["armed"] = armed;
+    doc["detections"] = detectionCount;
+    doc["wifi_rssi"] = WiFi.RSSI();
+    doc["free_heap"] = ESP.getFreeHeap();
+
+    char buf[256];
+    serializeJson(doc, buf, sizeof(buf));
+    mqtt.publish(TOPIC_STATUS, buf);
+}
+
+void publishArmedState() {
+    JsonDocument doc;
+    doc["node_id"] = NODE_ID;
+    doc["armed"] = armed;
+    doc["timestamp"] = millis();
+
+    char buf[128];
+    serializeJson(doc, buf, sizeof(buf));
+    mqtt.publish(TOPIC_ARMED, buf, true);  // retained
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Motion detection (simple frame differencing)
+// ════════════════════════════════════════════════════════════════════
+
+bool detectMotion(camera_fb_t *fb) {
+    if (!prevFrame || fb->format != PIXFORMAT_GRAYSCALE) return false;
+    if (fb->len != (320 * 240)) return false;
+
+    uint32_t changedPixels = 0;
+    uint8_t *curr = fb->buf;
+
+    for (size_t i = 0; i < fb->len; i++) {
+        int diff = abs((int)curr[i] - (int)prevFrame[i]);
+        if (diff > DETECT_THRESHOLD) {
+            changedPixels++;
+        }
+    }
+
+    // Save current frame as previous
+    memcpy(prevFrame, curr, fb->len);
+
+    return changedPixels > DETECT_MIN_AREA;
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Alarm control
+// ════════════════════════════════════════════════════════════════════
+
+void triggerAlarm(bool on) {
+    digitalWrite(PIN_BUZZER, on ? HIGH : LOW);
+    digitalWrite(PIN_LED_BEACON, on ? HIGH : LOW);
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Button handling
+// ════════════════════════════════════════════════════════════════════
+
+void checkButton() {
+    unsigned long now = millis();
+    if (now - lastButtonCheckMs < DEBOUNCE_MS) return;
+    lastButtonCheckMs = now;
+
+    bool currentState = digitalRead(PIN_BTN_ARM);
+    if (currentState == LOW && lastButtonState == HIGH) {
+        armed = !armed;
+        Serial.printf("[ARM] Button toggled, armed=%s\n", armed ? "true" : "false");
+        publishArmedState();
+        if (!armed) {
+            triggerAlarm(false);
+            digitalWrite(PIN_LED_BEACON, LOW);
+        }
+    }
+    lastButtonState = currentState;
+}
+
+// ════════════════════════════════════════════════════════════════════
+// MJPEG stream server
+// ════════════════════════════════════════════════════════════════════
+
+static const char *STREAM_CONTENT_TYPE = "multipart/x-mixed-replace;boundary=frame";
+static const char *STREAM_BOUNDARY = "\r\n--frame\r\n";
+static const char *STREAM_PART = "Content-Type: image/jpeg\r\nContent-Length: %u\r\n\r\n";
+
+esp_err_t streamHandler(httpd_req_t *req) {
+    esp_err_t res = httpd_resp_set_type(req, STREAM_CONTENT_TYPE);
+    if (res != ESP_OK) return res;
+
+    while (true) {
+        camera_fb_t *fb = esp_camera_fb_get();
+        if (!fb) {
+            Serial.println("[Stream] Frame capture failed");
+            break;
+        }
+
+        // For streaming, we need JPEG. Re-init camera to JPEG if needed
+        // or convert grayscale frame. For simplicity, send raw JPEG.
+        char partBuf[64];
+        snprintf(partBuf, sizeof(partBuf), STREAM_PART, fb->len);
+
+        res = httpd_resp_send_chunk(req, STREAM_BOUNDARY, strlen(STREAM_BOUNDARY));
+        if (res == ESP_OK)
+            res = httpd_resp_send_chunk(req, partBuf, strlen(partBuf));
+        if (res == ESP_OK)
+            res = httpd_resp_send_chunk(req, (const char *)fb->buf, fb->len);
+
+        esp_camera_fb_return(fb);
+
+        if (res != ESP_OK) break;
+    }
+    return res;
+}
+
+void setupStream() {
+    httpd_config_t config = HTTPD_DEFAULT_CONFIG();
+    config.server_port = STREAM_PORT;
+    config.ctrl_port = STREAM_PORT + 1;
+
+    httpd_uri_t streamUri = {
+        .uri = "/stream",
+        .method = HTTP_GET,
+        .handler = streamHandler,
+        .user_ctx = NULL
+    };
+
+    if (httpd_start(&streamServer, &config) == ESP_OK) {
+        httpd_register_uri_handler(streamServer, &streamUri);
+        Serial.printf("[Stream] MJPEG server on port %d\n", STREAM_PORT);
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for the Drone Net Launcher, a new Phase 1 product that extends the detect-decide-act chain into the air domain with an ESP32-C3 based air-to-air intercept node. It also updates the shared parts list and Phase 1 overview to reflect this new product.

## Key Changes

- **New documentation**: Added `phase1-drone-net-launcher.md` with complete build guide including:
  - Architecture and design rationale (why ESP32-C3 over ESP32-S)
  - Detailed bill of materials with weight budget analysis
  - Spring-loaded pin release mechanism design
  - Multi-layer safety architecture with state machine and heartbeat watchdog
  - Communication protocol (ARM/FIRE two-stage commands with bearer token auth)
  - Step-by-step build instructions (power, ESP32 setup, arm circuit, servo trigger, net assembly, integration testing)
  - Acceptance criteria and drone platform requirements
  - Upgrade path to Phase 1B+ features

- **Updated shared parts list** (`shared-parts.md`):
  - Added ESP32-C3 SuperMini specifications and sourcing info
  - Added AMS1117 mini buck converter to BOM
  - Added drone-specific components: SG90 servo, net mesh with weights, compression spring, silicone wire
  - Updated total BOM cost estimate from $55–85 to $75–110

- **Updated Phase 1 overview** (`overview.md`):
  - Added Drone Net Launcher as product #5 in the Phase 1 product set
  - Updated product table to reflect new intermediate complexity node
  - Updated shared components section to include drone-specific parts

## Notable Implementation Details

- **Safety-first design**: Implements physical arm switch + software state mirroring + two-stage remote commands + bearer token auth + heartbeat watchdog (reverts to SAFE on comms loss ≤1.5s) + single-shot lockout
- **Weight-optimized**: Total payload ~112-162g using ESP32-C3 (5g bare module) instead of heavier alternatives
- **Human-in-the-loop only**: No autonomous firing; operator must manually arm and command fire
- **Reloadable mechanism**: Spring + servo design avoids consumables (CO2, pyrotechnics) for easier iteration
- **Extensible protocol**: HTTP endpoints for `/arm`, `/fire`, `/safe`, `/status` with heartbeat telemetry for future MQTT/TLS upgrades

https://claude.ai/code/session_01W2zDVSLewNy3hKHNQbzTzD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added full Phase 1A technical docs for a Drone Net Launcher: concept, two deployment mechanisms, engagement flow, safety-chain/arming procedure, comms/heartbeat behavior, BOMs, wiring diagrams, build/integration steps, testing and safety guidance.
  * Updated Phase 1 overview and shared parts with new ESP32-C3 board entry, expanded BOM, sourcing, weight and revised pricing/coverage.

* **New Features**
  * Added a three-node ESP32 demo stack (camera/detection, hub, relay) with wiring, MQTT-based arming/triggering, heartbeat, and MJPEG streaming support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->