### PR TITLE
docs: Add spare parts bin inventory document

### DIFF
--- a/apps/docs/docs/research/spare-parts-bin.md
+++ b/apps/docs/docs/research/spare-parts-bin.md
@@ -1,0 +1,155 @@
+# Spare Parts Bin — Identified Components Inventory
+
+Catalogue of salvaged components identified from around the workshop. Assessed
+for usefulness across **all projects** — not just Phoenix Rooivalk drone builds.
+
+**Legend:**
+- **Rooivalk** = Drone upgrade paths (A/B/C) and counter-UAS platform
+- **IoT/Smart Home** = ESP32, Tuya, Home Assistant, sensor networks
+- **Networking** = Ground stations, mesh networks, lab infrastructure
+- **Audio/Media** = Bluetooth speakers, media projects
+- **General Electronics** = Bench tools, prototyping, learning
+
+---
+
+## Master Inventory Table
+
+| # | Component | Description | Condition | Useful For | Rooivalk? | Keep/Toss |
+|---|-----------|-------------|-----------|------------|-----------|-----------|
+| 1 | Cudy WR3000 WiFi 6 Router | MediaTek MT7981B SoC, WiFi 6, dual-band, OpenWrt compatible | Working | Ground station networking, mesh relay, OpenWrt lab, VPN endpoint | Yes — ground station | **Keep** |
+| 2 | Older MT7615DN WiFi Router | MediaTek MT7615DN chipset, 2.4/5GHz, larger form factor | Working | Backup router, 2.4GHz antenna donor, OpenWrt experiments | Marginal — antenna salvage | **Keep (antennas)** |
+| 3 | PS4 DualShock 4 (JDM-011) | Sony CUH-ZCT1U controller, Bluetooth + USB, analog sticks, IMU | Working | Gaming, DIY RC controller (analog sticks), Bluetooth HID input | Yes — manual override controller | **Keep** |
+| 4 | RC Toy Motor Controller PCB | Blue PCB from cheap RC car, H-bridge brushed motor driver, piezo buzzer | Working | Piezo buzzer salvage, learning H-bridge circuits | No | **Keep (buzzer only)** |
+| 5 | USB Wall Charger PCB | 5V USB-A output, mains AC input, bare PCB (no enclosure) | Working | Bench 5V supply, powering dev boards, phone charging | Indirect — bench power | **Keep** |
+| 6 | 1S-to-5V USB Boost Converter | Small PCB, single-cell LiPo input, 5V USB output, ~1A | Working | Portable RPi power testing, field USB charging from LiPo | Yes — field power for companion computer | **Keep** |
+| 7 | Tuya WR3E WiFi Module | RTL8710BN-based, 2.4GHz WiFi, reflashable (LibreTiny/ESPHome) | Working | IoT sensor nodes, WiFi telemetry bridge, smart home devices | Yes — lightweight WiFi telemetry | **Keep** |
+| 8 | Laptop 56K Modem Card | Mini-PCIe dial-up modem, RJ-11 jack | Unknown | Nothing — obsolete technology, no modern use | No | **Toss** |
+| 9 | Fanhar Relay Module | Single-channel 5V relay, opto-isolated, screw terminals | Working | Home automation, irrigation control, power switching circuits | No (too heavy for drone) | **Keep** |
+| 10 | Tactile Push Button Breakout | Small PCB with single tactile switch, 2-pin header | Working | Prototyping reset/boot buttons, breadboard projects | Marginal — parts bin filler | **Keep** |
+| 11 | Parrot Minikit+ Main Board (MPP_MB_07) | Bluetooth 2.1+EDR car kit, CSR BlueCore5 chipset, MEMS mic, speaker amp | Working | Bluetooth audio experiments, hands-free intercom, DSP learning | No | **Keep (learning)** |
+| 12 | Parrot Minikit+ Clip/Mount Assembly | Visor clip mechanism with speaker grille and mic housing | Working | Enclosure/mount reference for 3D printing projects | No | **Keep** |
+| 13 | Parrot Minikit+ Button Membrane + Light Pipe | Silicone button pad with integrated light guides for status LEDs | Working | UI reference for custom enclosures, LED light pipe examples | No | **Keep (reference)** |
+| 14 | Bluetooth Audio Receiver Module | Small PCB, BT audio sink, 3.5mm or solder pad output | Working | Portable Bluetooth speaker builds, audio streaming to amp | No | **Keep** |
+| 15 | LED Driver / Voltage Doubler Tiny PCB | Charge-pump circuit, ~10mm PCB, likely white LED backlight driver | Unknown | Very limited — niche LED driving only | No | **Toss** |
+
+---
+
+## Detailed Notes by Component
+
+### 1. Cudy WR3000 WiFi 6 Router
+
+**Best use:** Flash OpenWrt and deploy as a dedicated ground station router for
+the drone project. WiFi 6 gives better range and throughput for FPV video relay
+or MAVLink telemetry forwarding. Can also serve as a portable lab router or VPN
+gateway.
+
+**Cross-project:** Excellent general-purpose networking device. OpenWrt turns it
+into a firewall, VPN endpoint, mesh node, or captive portal.
+
+### 2. Older MT7615DN WiFi Router
+
+**Best use:** The 2.4GHz antenna (SMA or RP-SMA) can be salvaged for other
+RF projects. The router itself is a backup if the Cudy dies. MT7615DN has
+decent Linux driver support.
+
+**Cross-project:** OpenWrt test bed, antenna donor.
+
+### 3. PS4 DualShock 4 (JDM-011)
+
+**Best use:** Use as a manual override controller for the drone via Bluetooth
+HID to a companion computer (RPi). The dual analog sticks map naturally to
+throttle/yaw and pitch/roll. Has a built-in IMU (accelerometer + gyro) and
+touchpad.
+
+**Cross-project:** Gaming, robotics control, any project needing analog input.
+
+### 4. RC Toy Motor Controller PCB
+
+**Best use:** The piezo buzzer is worth desoldering — useful as a lost-model
+alarm or status beeper on any build. The H-bridge driver IC is too weak and
+undocumented for reuse.
+
+**Cross-project:** Electronics learning, piezo salvage.
+
+### 5. USB Wall Charger PCB
+
+**Best use:** Bench 5V supply for dev boards (ESP32, Arduino, RPi Zero). Keep it
+in a safe enclosure since it handles mains voltage.
+
+**Cross-project:** Universal bench tool.
+
+### 6. 1S-to-5V USB Boost Converter
+
+**Best use:** Power a RPi Zero 2W from a single-cell LiPo for field testing the
+AI companion computer tier. Also useful for any portable USB-powered device.
+
+**Cross-project:** Portable power for any 5V device from LiPo cells.
+
+### 7. Tuya WR3E WiFi Module (RTL8710BN)
+
+**Best use:** Reflash with LibreTiny or OpenBeken firmware. Use as a lightweight
+WiFi telemetry bridge (UART-to-WiFi) for drone status data, or deploy in IoT
+sensor nodes around the house.
+
+**Cross-project:** Smart home sensors, WiFi-controlled relays, environmental
+monitoring, any UART-to-WiFi bridge need.
+
+### 8. Laptop 56K Modem Card
+
+**Best use:** None. Dial-up is dead. No salvageable components worth the effort.
+
+### 9. Fanhar Relay Module
+
+**Best use:** Home automation — switching pumps, lights, irrigation valves. The
+opto-isolation makes it safe to drive from 3.3V microcontrollers.
+
+**Cross-project:** Irrigation, lighting control, power switching for any
+project that needs to toggle mains or high-current DC loads.
+
+### 10. Tactile Push Button Breakout
+
+**Best use:** Breadboard prototyping. Keep in the parts bin for when you need a
+quick button input on any project.
+
+### 11-13. Parrot Minikit+ Components
+
+**Best use:** The CSR BlueCore5 Bluetooth chipset is a capable BT 2.1 audio
+device. The MEMS microphone and speaker amplifier could be reused in an
+intercom or audio monitoring project. The clip mount and button membrane are
+good physical design references if you're 3D printing enclosures.
+
+**Cross-project:** Bluetooth audio experiments, enclosure design reference.
+
+### 14. Bluetooth Audio Receiver Module
+
+**Best use:** Build a portable Bluetooth speaker with a salvaged driver and
+amplifier. Pair with a power bank for a camping/workshop speaker.
+
+**Cross-project:** Audio streaming to any amplifier setup.
+
+### 15. LED Driver / Voltage Doubler
+
+**Best use:** Very limited. Charge-pump voltage doublers are cheap and
+application-specific. Not worth designing around.
+
+---
+
+## Summary by Project Applicability
+
+| Project | Useful Components |
+|---------|-------------------|
+| **Rooivalk Drone (Paths A/B/C)** | #1 (ground station), #3 (controller), #6 (field power), #7 (telemetry) |
+| **IoT / Smart Home** | #7 (WiFi nodes), #9 (relay switching), #5 (bench power), #10 (buttons) |
+| **Networking / Lab** | #1 (OpenWrt router), #2 (backup/antenna donor) |
+| **Audio / Media** | #11 (Bluetooth car kit), #14 (BT audio receiver) |
+| **General Prototyping** | #4 (piezo buzzer), #5 (5V supply), #6 (boost converter), #10 (button) |
+| **Toss Pile** | #8 (56K modem), #15 (LED driver) |
+
+---
+
+## Storage Recommendations
+
+- **Anti-static bag:** #7 (WiFi module), #11 (Parrot board), #14 (BT module)
+- **Labelled bin:** #4 (buzzer), #9 (relay), #10 (button), #6 (boost converter)
+- **Shelf/rack:** #1 (Cudy router), #2 (old router), #3 (PS4 controller)
+- **Recycling:** #8 (modem), #15 (LED driver)

--- a/apps/docs/docs/research/spare-parts-bin.md
+++ b/apps/docs/docs/research/spare-parts-bin.md
@@ -44,6 +44,16 @@ detailed keep/scrap/toss reasoning on each component.
 | 12 | Bluetooth Audio Receiver Module | 1 | Small PCB, BT audio sink, 3.5mm or solder pad output | Working | Portable Bluetooth speaker builds, audio streaming to amp | No | **Keep** |
 | 13 | LED Driver / Voltage Doubler Tiny PCB | 1 | Charge-pump circuit, ~10mm PCB, likely white LED backlight driver | Unknown | Very limited — niche LED driving only | No | **Toss** |
 | 14 | Piezo Buzzer (from RC toy board) | 1 | Through-hole piezo disc, salvaged from toy car controller | Working | Lost-model alarm, status beeper, audible alerts | Yes — lost-model buzzer | **Keep** |
+| 15 | Panasonic Washing Machine Button Panel | 1 | Part A4274008084, 3x rocker switches, phenolic PCB, ribbon cable | Unknown | Nothing — proprietary form factor | No | **Toss** |
+| 16 | LG TV T-Con Board | 1 | EAX36987601, Panasonic MN-series QFP ICs, LVDS timing controller | Unknown | Nothing — proprietary display controller | No | **Toss** |
+| 17 | ZyXEL CB71 Gateway | 1 | EMG2926-T50C, dual-band WiFi 5, 4x LAN + 1x WAN, 12V/1.5A | Working | Managed switch (4 LAN ports), backup router, OpenWrt (limited) | Marginal — LAN switch | **Keep (test first)** |
+| 18 | D-Link DSL-2640U | 1 | ADSL2+ modem/router, 802.11n, FW v2.01, very old | Working | Nothing — ADSL-only, ancient, slow | No | **Toss** |
+| 19 | Huawei B315s-936 | 1 | 4G LTE Cat 4 router, SIM slot, WiFi, 12V/1A, IMEI on label | Working | Mobile internet anywhere, field data link, backup WAN, portable hotspot | Yes — 4G field link for ground station | **Keep** |
+| 20a | Vodafone H 500-s | 1 | Dual-band WiFi 5 (2.4+5GHz), 12V/2.5A, ISP-branded gateway | Working | Backup router, test network, OpenWrt (limited) | Marginal | **Keep (better unit)** |
+| 20b | Vodafone H 500-s (duplicate) | 1 | Same as 20a | Working | Nothing — redundant | No | **Toss** |
+| 21 | Wall-Wart Power Adapters (assorted) | ~6 | Mix of 5V/9V/12V barrel-jack DC adapters, SA 2-pin plugs | Test needed | Bench PSUs for routers, dev boards, any 12V/5V device | Indirect — bench power | **Keep (tested ones)** |
+| 22 | NiMH Quick Charger | 1 | AA/AAA NiMH battery charger, mains powered | Working | Rechargeable battery maintenance, AA/AAA for remotes/sensors | No | **Keep** |
+| 23 | BenQ Monitor (disassembled) | 1 | Old CCFL-backlit LCD, VGA+DVI only, BenQ senseye scaler board, 4H.L2E02.A34 PSU/inverter board. **450V caps — dangerous** | Unknown | Nothing — no HDMI, CCFL obsolete, VGA/DVI dead | No | **Toss (safely)** |
 
 ---
 
@@ -191,14 +201,14 @@ amplifier. Pair with a power bank for a camping/workshop speaker.
 
 | Project | Useful Components |
 |---------|-------------------|
-| **Rooivalk Drone (Paths A/B/C)** | #1 (ground station), #3 (controller), #6 (field power), #7 (telemetry), #11 (acoustic detection), #14 (buzzer) |
+| **Rooivalk Drone (Paths A/B/C)** | #1 (ground station), #3 (controller), #6 (field power), #7 (telemetry), #11 (acoustic detection), #14 (buzzer), #19 (4G field link) |
 | **Ground Rover / Robotics** | #4a (motor controller), #4c (hub motors), #3 (PS4 controller), #4d (MOSFETs) |
 | **IoT / Smart Home** | #7 (WiFi nodes), #9 (relay switching), #5 (bench power), #10 (buttons), #11 (BT serial bridge) |
-| **Networking / Lab** | #1 (OpenWrt router), #2 (backup/antenna donor) |
+| **Networking / Lab** | #1 (OpenWrt router), #2 (backup/antenna donor), #17 (ZyXEL switch), #19 (4G LTE), #20a (Vodafone backup) |
 | **Audio / Media** | #11 (Parrot BT kit), #12 (BT audio receiver) |
 | **EV / High-Power Builds** | #4a (BLDC controller), #4c (hub motors), #4d (power MOSFETs), #4e (current shunts) |
-| **General Prototyping** | #14 (piezo buzzer), #5 (5V supply), #6 (boost converter), #10 (button), #4e-g (harvested parts) |
-| **Toss Pile** | #8 (56K modem), #13 (LED driver) |
+| **General Prototyping** | #14 (piezo buzzer), #5 (5V supply), #6 (boost converter), #10 (button), #4e-g (harvested parts), #21 (PSUs), #22 (charger) |
+| **Toss Pile** | #8 (56K modem), #13 (LED driver), #15 (washer panel), #16 (T-Con), #18 (D-Link DSL), #20b (dupe Vodafone), #23 (BenQ monitor) |
 
 ---
 
@@ -206,6 +216,6 @@ amplifier. Pair with a power bank for a camping/workshop speaker.
 
 - **Keep assembled:** #4a (intact hoverboard board — do not strip), #11 (Parrot kit — more valuable intact)
 - **Anti-static bag:** #7 (WiFi module), #12 (BT module), #4d-g (harvested hoverboard parts)
-- **Labelled bin:** #14 (buzzer), #9 (relay), #10 (button), #6 (boost converter)
-- **Shelf/rack:** #1 (Cudy router), #2 (old router), #3 (PS4 controller), #4c (hub motors)
-- **E-waste recycling:** #8 (56K modem), #13 (LED driver), RC toy board (after buzzer removed)
+- **Labelled bin:** #14 (buzzer), #9 (relay), #10 (button), #6 (boost converter), #21 (tested PSUs)
+- **Shelf/rack:** #1 (Cudy router), #2 (old router), #3 (PS4 controller), #4c (hub motors), #17 (ZyXEL), #19 (Huawei 4G), #20a (Vodafone), #22 (NiMH charger)
+- **E-waste recycling:** #8 (56K modem), #13 (LED driver), #15 (washer panel), #16 (T-Con), #18 (D-Link DSL), #20b (dupe Vodafone), #23 (BenQ — **discharge 450V caps first**), RC toy board (after buzzer removed)

--- a/apps/docs/docs/research/spare-parts-bin.md
+++ b/apps/docs/docs/research/spare-parts-bin.md
@@ -3,9 +3,12 @@
 Catalogue of salvaged components identified from around the workshop. Assessed
 for usefulness across **all projects** — not just Phoenix Rooivalk drone builds.
 
-> **Note:** The original toy quadcopter (X8-class, 320mm diagonal) documented in
-> the hardware teardown has been stolen. Upgrade paths A/B/C will require a new
-> donor airframe or proceed directly to Path B (new frame build).
+> **Note:** The Parrot Minikit+ was associated with a Parrot drone that has been
+> stolen. The toy quadcopter (X8-class, 320mm diagonal) for upgrade paths A/B/C
+> is still available.
+
+**Decision records:** See [Spare Parts Decisions](./spare-parts-decisions.md) for
+detailed keep/scrap/toss reasoning on each component.
 
 **Legend:**
 - **Rooivalk** = Drone upgrade paths (A/B/C) and counter-UAS platform

--- a/apps/docs/docs/research/spare-parts-bin.md
+++ b/apps/docs/docs/research/spare-parts-bin.md
@@ -10,190 +10,64 @@ for usefulness across **all projects** — not just Phoenix Rooivalk drone build
 **Decision records:** See [Spare Parts Decisions](./spare-parts-decisions.md) for
 detailed keep/scrap/toss reasoning on each component.
 
+**Stripping approach:** A dedicated person handles all disassembly — labour is
+free. The question is not "is it worth the effort" but rather "is the component
+useful once removed?" and "what's the learning value?" Items marked **Strip**
+get disassembled for parts. Items marked **Toss** have nothing useful even with
+free labour.
+
 **Legend:**
 - **Rooivalk** = Drone upgrade paths (A/B/C) and counter-UAS platform
 - **IoT/Smart Home** = ESP32, Tuya, Home Assistant, sensor networks
 - **Networking** = Ground stations, mesh networks, lab infrastructure
 - **Audio/Media** = Bluetooth speakers, media projects
 - **Robotics/EV** = Ground vehicles, rovers, electric builds
-- **General Electronics** = Bench tools, prototyping, learning
+- **Bench/Power** = Power supplies, test equipment, bench tools
+- **General Electronics** = Prototyping, learning, parts bin
 
 ---
 
 ## Master Inventory Table
 
-| # | Component | Qty | Description | Condition | Useful For | Rooivalk? | Keep/Toss |
-|---|-----------|-----|-------------|-----------|------------|-----------|-----------|
-| 1 | Cudy WR3000 WiFi 6 Router | 1 | MediaTek MT7981B SoC, WiFi 6, dual-band, OpenWrt compatible | Working | Ground station networking, mesh relay, OpenWrt lab, VPN endpoint | Yes — ground station | **Keep** |
-| 2 | Older MT7615DN WiFi Router | 1 | MediaTek MT7615DN chipset, 2.4/5GHz, larger form factor | Working | Backup router, 2.4GHz antenna donor, OpenWrt experiments | Marginal — antenna salvage | **Keep (antennas)** |
-| 3 | PS4 DualShock 4 (JDM-011) | 1 | Sony CUH-ZCT1U controller, Bluetooth + USB, analog sticks, IMU | Working | Gaming, DIY RC controller (analog sticks), Bluetooth HID input | Yes — manual override controller | **Keep** |
-| 4a | Hoverboard Controller Board (intact) | 1 | Blue PCB, dual 3-phase BLDC driver, STM32/GD32 MCU, power MOSFETs, hall sensor inputs, JST-XH connectors, 36V rated | Working | Dual BLDC motor controller — robot platform, electric go-kart, belt grinder, CNC spindle driver. Reflashable with open-source FOC firmware | Yes — ground rover platform | **Keep (intact)** |
-| 4b | Hoverboard Controller Board (harvest) | 1 | Same as 4a — designated for component salvage | Working | MOSFET harvesting, current sense resistors, capacitors, connectors | Parts donor | **Keep (harvest)** |
-| 4c | Hoverboard Hub Motors | 2 | 36V 250-350W brushless DC hub motors, ~6.5" wheel with tyre | Working | Electric skateboard, go-kart, robot rover, belt grinder, lathe spindle. Most valuable items in the bin (~R500+ each) | Yes — ground rover | **Keep** |
-| 4d | Hoverboard Power MOSFETs (from 4b) | 6-8 | CLN89 or similar N-channel D-PAK, 60-100V 30A+ rated | Harvestable | High-current switching: motor drivers, DC-DC converters, power supplies, e-bike controllers | Yes — custom ESC builds | **Harvest** |
-| 4e | Hoverboard Current Sense Resistors (from 4b) | 4+ | R004/R010 low-ohm precision shunt resistors | Harvestable | Motor/battery current monitoring on any power project | Yes — current sensing | **Harvest** |
+| # | Component | Qty | Description | Condition | Useful For | Rooivalk? | Action |
+|---|-----------|-----|-------------|-----------|------------|-----------|--------|
+| 1 | Cudy WR3000 WiFi 6 Router | 1 | MediaTek MT7981B SoC, WiFi 6, dual-band, OpenWrt compatible | Working | Ground station networking, mesh relay, OpenWrt lab, VPN endpoint | Yes — ground station | **Keep intact** |
+| 2 | Older MT7615DN WiFi Router | 1 | MediaTek MT7615DN chipset, 2.4/5GHz, larger form factor | Working | Backup router, 2.4GHz antenna donor, OpenWrt experiments | Marginal — antenna salvage | **Keep** |
+| 3 | PS4 DualShock 4 (JDM-011) | 1 | Sony CUH-ZCT1U controller, Bluetooth + USB, analog sticks, IMU | Working | Gaming, DIY RC controller, Bluetooth HID input, robotics | Yes — manual override controller | **Keep intact** |
+| 4a | Hoverboard Controller Board (intact) | 1 | Blue PCB, dual 3-phase BLDC driver, STM32/GD32 MCU, power MOSFETs, hall sensor inputs, JST-XH connectors, 36V rated | Working | Dual BLDC motor controller — robot platform, go-kart, CNC. Reflashable with open-source FOC firmware | Yes — ground rover platform | **Keep intact** |
+| 4b | Hoverboard Controller Board (harvest) | 1 | Same as 4a — designated for component salvage | Working | MOSFET harvesting, current sense resistors, capacitors, connectors | Parts donor | **Strip** |
+| 4c | Hoverboard Hub Motors | 2 | 36V 250-350W brushless DC hub motors, ~6.5" wheel with tyre | Working | Robot rover, go-kart, belt grinder, lathe spindle. ~R500+ each | Yes — ground rover | **Keep** |
+| 4d | Hoverboard Power MOSFETs (from 4b) | 6-8 | CLN89 or similar N-channel D-PAK, 60-100V 30A+ rated | Harvestable | High-current switching: motor drivers, DC-DC converters, ESC builds | Yes — custom ESC | **Harvest (priority)** |
+| 4e | Hoverboard Current Sense Resistors (from 4b) | 4+ | R004/R010 low-ohm precision shunt resistors | Harvestable | Motor/battery current monitoring on any power project | Yes — current sensing | **Harvest (priority)** |
 | 4f | Hoverboard Electrolytic Caps (from 4b) | 2-4 | 220uF 35-50V rated | Harvestable | Power supply filtering on any 12-36V project | General use | **Harvest** |
 | 4g | Hoverboard JST-XH Connectors (from 4b) | 6+ | 2.54mm pitch, multi-pin, through-hole, white | Harvestable | Reusable connectors for any project wiring | General use | **Harvest** |
-| 5 | USB Wall Charger PCB | 1 | 5V USB-A output, mains AC input, bare PCB (no enclosure) | Working | Bench 5V supply, powering dev boards, phone charging | Indirect — bench power | **Keep** |
-| 6 | 1S-to-5V USB Boost Converter | 1 | Small PCB, single-cell LiPo input, 5V USB output, ~1A | Working | Portable RPi power testing, field USB charging from LiPo | Yes — field power for companion computer | **Keep** |
-| 7 | Tuya WR3E WiFi Module | 1 | RTL8710BN-based, 2.4GHz WiFi, reflashable (LibreTiny/ESPHome) | Working | IoT sensor nodes, WiFi telemetry bridge, smart home devices | Yes — lightweight WiFi telemetry | **Keep** |
-| 8 | Laptop 56K Modem Card | 1 | Mini-PCIe dial-up modem, RJ-11 jack | Unknown | Nothing — obsolete technology, no modern use | No | **Toss** |
-| 9 | Fanhar Relay Module | 1 | Single-channel 5V relay, opto-isolated, screw terminals | Working | Home automation, irrigation control, power switching circuits | No (too heavy for drone) | **Keep** |
-| 10 | Tactile Push Button Breakout | 1 | Small PCB with single tactile switch, 2-pin header | Working | Prototyping reset/boot buttons, breadboard projects | Marginal — parts bin filler | **Keep** |
-| 11 | Parrot Minikit+ Complete Unit (MPP_MB_07) | 1 | Bluetooth 2.1+EDR car kit — CSR BlueCore5 MCU, MEMS mic, Class D speaker amp, status LEDs, clip mount, button membrane with light pipes. Fully intact | Working | Bluetooth audio sink/source, hands-free intercom, voice-activated trigger, BT serial bridge (SPP profile), MEMS mic for acoustic detection | Yes — acoustic drone detection sensor, BT serial bridge | **Keep** |
-| 12 | Bluetooth Audio Receiver Module | 1 | Small PCB, BT audio sink, 3.5mm or solder pad output | Working | Portable Bluetooth speaker builds, audio streaming to amp | No | **Keep** |
-| 13 | LED Driver / Voltage Doubler Tiny PCB | 1 | Charge-pump circuit, ~10mm PCB, likely white LED backlight driver | Unknown | Very limited — niche LED driving only | No | **Toss** |
-| 14 | Piezo Buzzer (from RC toy board) | 1 | Through-hole piezo disc, salvaged from toy car controller | Working | Lost-model alarm, status beeper, audible alerts | Yes — lost-model buzzer | **Keep** |
-| 15 | Panasonic Washing Machine Button Panel | 1 | Part A4274008084, 3x rocker switches, phenolic PCB, ribbon cable | Unknown | Nothing — proprietary form factor | No | **Toss** |
-| 16 | LG TV T-Con Board | 1 | EAX36987601, Panasonic MN-series QFP ICs, LVDS timing controller | Unknown | Nothing — proprietary display controller | No | **Toss** |
-| 17 | ZyXEL CB71 Gateway | 1 | EMG2926-T50C, dual-band WiFi 5, 4x LAN + 1x WAN, 12V/1.5A | Working | Managed switch (4 LAN ports), backup router, OpenWrt (limited) | Marginal — LAN switch | **Keep (test first)** |
-| 18 | D-Link DSL-2640U | 1 | ADSL2+ modem/router, 802.11n, FW v2.01, very old | Working | Nothing — ADSL-only, ancient, slow | No | **Toss** |
-| 19 | Huawei B315s-936 | 1 | 4G LTE Cat 4 router, SIM slot, WiFi, 12V/1A, IMEI on label | Working | Mobile internet anywhere, field data link, backup WAN, portable hotspot | Yes — 4G field link for ground station | **Keep** |
-| 20a | Vodafone H 500-s | 1 | Dual-band WiFi 5 (2.4+5GHz), 12V/2.5A, ISP-branded gateway | Working | Backup router, test network, OpenWrt (limited) | Marginal | **Keep (better unit)** |
-| 20b | Vodafone H 500-s (duplicate) | 1 | Same as 20a | Working | Nothing — redundant | No | **Toss** |
+| 5 | USB Wall Charger PCB | 1 | 5V USB-A output, mains AC input, bare PCB (no enclosure) | Working | Bench 5V supply, powering dev boards | Indirect — bench power | **Keep** |
+| 6 | 1S-to-5V USB Boost Converter | 1 | Small PCB, single-cell LiPo input, 5V USB output, ~1A | Working | Portable RPi power, field USB charging from LiPo | Yes — field power | **Keep** |
+| 7 | Tuya WR3E WiFi Module | 1 | RTL8710BN-based, 2.4GHz WiFi, reflashable (LibreTiny/ESPHome) | Working | IoT sensor nodes, WiFi telemetry bridge, smart home | Yes — WiFi telemetry | **Keep** |
+| 8 | Laptop 56K Modem Card | 1 | Mini-PCIe dial-up modem, RJ-11 jack | Unknown | Nothing — obsolete technology | No | **Strip (learning)** |
+| 9 | Fanhar Relay Module | 1 | Single-channel 5V relay, opto-isolated, screw terminals | Working | Home automation, irrigation, power switching | No (too heavy) | **Keep** |
+| 10 | Tactile Push Button Breakout | 1 | Small PCB with single tactile switch, 2-pin header | Working | Prototyping reset/boot buttons, breadboard projects | Marginal | **Keep** |
+| 11 | Parrot Minikit+ Complete Unit (MPP_MB_07) | 1 | Bluetooth 2.1+EDR car kit — CSR BlueCore5 MCU, MEMS mic, Class D speaker amp, status LEDs, clip mount, button membrane with light pipes. Fully intact | Working | BT serial bridge, acoustic drone detection, intercom, audio sink | Yes — acoustic detection, BT bridge | **Keep intact** |
+| 12 | Bluetooth Audio Receiver Module | 1 | Small PCB, BT audio sink, 3.5mm or solder pad output | Working | Portable Bluetooth speaker builds, audio streaming | No | **Keep** |
+| 13 | LED Driver / Voltage Doubler Tiny PCB | 1 | Charge-pump circuit, ~10mm PCB, unmarked IC | Unknown | Nothing — too small, unmarked, no learning value | No | **Toss** |
+| 14 | Piezo Buzzer (from RC toy board) | 1 | Through-hole piezo disc, salvaged from toy car controller | Working | Lost-model alarm, status beeper, audible alerts | Yes — buzzer | **Keep** |
+| 15 | Panasonic Washing Machine Button Panel | 1 | Part A4274008084, 3x rocker switches, phenolic PCB, ribbon cable | Unknown | Switches are proprietary form factor but board is good desoldering practice | No | **Strip (learning)** |
+| 16 | LG TV T-Con Board | 1 | EAX36987601, Panasonic MN-series QFP ICs, FPC connector | Unknown | QFP desoldering practice, SMD rework learning | No | **Strip (learning)** |
+| 17 | ZyXEL CB71 Gateway | 1 | EMG2926-T50C, dual-band WiFi 5, 4x LAN + 1x WAN, 12V/1.5A | Working | 4-port Gigabit switch, backup AP, test network isolation | Marginal — LAN switch | **Keep (test first)** |
+| 18 | D-Link DSL-2640U | 1 | ADSL2+ modem/router, 802.11n, FW v2.01 | Working | RJ-45 jacks, board-level teardown practice, OpenWrt learning | No | **Strip (learning)** |
+| 19 | Huawei B315s-936 | 1 | 4G LTE Cat 4 router, SIM slot, WiFi, 12V/1A | Working | Mobile internet, field data link, backup WAN, portable hotspot | Yes — 4G field link | **Keep intact** |
+| 20a | Vodafone H 500-s | 1 | Dual-band WiFi 5 (2.4+5GHz), 12V/2.5A, ISP-branded gateway | Working | Backup router, test network, workshop AP | Marginal | **Keep** |
+| 20b | Vodafone H 500-s (duplicate) | 1 | Same as 20a | Working | Strip practice, SoC identification, heatsink/antenna salvage | No | **Strip (learning)** |
 | 21 | Wall-Wart Power Adapters (assorted) | ~6 | Mix of 5V/9V/12V barrel-jack DC adapters, SA 2-pin plugs | Test needed | Bench PSUs for routers, dev boards, any 12V/5V device | Indirect — bench power | **Keep (tested ones)** |
-| 22 | NiMH Quick Charger | 1 | AA/AAA NiMH battery charger, mains powered | Working | Rechargeable battery maintenance, AA/AAA for remotes/sensors | No | **Keep** |
-| 23 | BenQ Monitor (disassembled) | 1 | Old CCFL-backlit LCD, VGA+DVI only, BenQ senseye scaler board, 4H.L2E02.A34 PSU/inverter board. **450V caps — dangerous** | Unknown | Nothing — no HDMI, CCFL obsolete, VGA/DVI dead | No | **Toss (safely)** |
-
----
-
-## Detailed Notes by Component
-
-### 1. Cudy WR3000 WiFi 6 Router
-
-**Best use:** Flash OpenWrt and deploy as a dedicated ground station router for
-the drone project. WiFi 6 gives better range and throughput for FPV video relay
-or MAVLink telemetry forwarding. Can also serve as a portable lab router or VPN
-gateway.
-
-**Cross-project:** Excellent general-purpose networking device. OpenWrt turns it
-into a firewall, VPN endpoint, mesh node, or captive portal.
-
-### 2. Older MT7615DN WiFi Router
-
-**Best use:** The 2.4GHz antenna (SMA or RP-SMA) can be salvaged for other
-RF projects. The router itself is a backup if the Cudy dies. MT7615DN has
-decent Linux driver support.
-
-**Cross-project:** OpenWrt test bed, antenna donor.
-
-### 3. PS4 DualShock 4 (JDM-011)
-
-**Best use:** Use as a manual override controller for the drone via Bluetooth
-HID to a companion computer (RPi). The dual analog sticks map naturally to
-throttle/yaw and pitch/roll. Has a built-in IMU (accelerometer + gyro) and
-touchpad.
-
-**Cross-project:** Gaming, robotics control, any project needing analog input.
-
-### 4a-g. Hoverboard Components (x2 boards, x2 hub motors)
-
-Salvaged from two self-balancing scooters (hoverboards). These are **the most
-valuable items in the entire spare parts bin**.
-
-**Board A (keep intact):** Flash with open-source FOC firmware
-(e.g. [EFeru/hoverboard-firmware-hack-FOC](https://github.com/EFeru/hoverboard-firmware-hack-FOC)).
-This gives you a ready-made dual BLDC motor controller with hall sensor inputs,
-current sensing, UART/I2C control interface, and 36V power handling. Perfect
-base for a ground rover, electric go-kart, or autonomous robot platform.
-
-**Board B (harvest):** Desolder the power MOSFETs (CLN89 or similar — D-PAK
-package, easy with hot air or wide chisel tip). These are 60-100V, 30A+
-N-channel FETs — genuinely expensive to buy individually and useful for any
-high-current project. Also harvest the R004/R010 current sense resistors
-(precision shunts, annoying to source), the 220uF caps, and the JST-XH
-connectors.
-
-**Hub motors (x2):** 36V 250-350W BLDC hub motors with integrated tyres.
-Worth R500+ each new. Use cases: robot rover, electric skateboard, belt grinder,
-lathe spindle, go-kart, wheelchair conversion, conveyor drive.
-
-**Rooivalk relevance:** Not for the drone itself (way too heavy), but highly
-relevant for a ground-based counter-UAS rover platform or autonomous patrol
-vehicle. Combined with the PS4 controller (#3) and a RPi, you have the bones of
-a remote-controlled ground station on wheels.
-
-### 14. Piezo Buzzer (salvaged from RC toy board)
-
-**Best use:** Lost-model alarm or status beeper on any drone build. Desolder
-from the good RC toy board (5 seconds, two wires). Toss the rest of that board.
-
-**Cross-project:** Any project needing audible feedback.
-
-### 5. USB Wall Charger PCB
-
-**Best use:** Bench 5V supply for dev boards (ESP32, Arduino, RPi Zero). Keep it
-in a safe enclosure since it handles mains voltage.
-
-**Cross-project:** Universal bench tool.
-
-### 6. 1S-to-5V USB Boost Converter
-
-**Best use:** Power a RPi Zero 2W from a single-cell LiPo for field testing the
-AI companion computer tier. Also useful for any portable USB-powered device.
-
-**Cross-project:** Portable power for any 5V device from LiPo cells.
-
-### 7. Tuya WR3E WiFi Module (RTL8710BN)
-
-**Best use:** Reflash with LibreTiny or OpenBeken firmware. Use as a lightweight
-WiFi telemetry bridge (UART-to-WiFi) for drone status data, or deploy in IoT
-sensor nodes around the house.
-
-**Cross-project:** Smart home sensors, WiFi-controlled relays, environmental
-monitoring, any UART-to-WiFi bridge need.
-
-### 8. Laptop 56K Modem Card
-
-**Best use:** None. Dial-up is dead. No salvageable components worth the effort.
-
-### 9. Fanhar Relay Module
-
-**Best use:** Home automation — switching pumps, lights, irrigation valves. The
-opto-isolation makes it safe to drive from 3.3V microcontrollers.
-
-**Cross-project:** Irrigation, lighting control, power switching for any
-project that needs to toggle mains or high-current DC loads.
-
-### 10. Tactile Push Button Breakout
-
-**Best use:** Breadboard prototyping. Keep in the parts bin for when you need a
-quick button input on any project.
-
-### 11. Parrot Minikit+ Complete Unit
-
-Fully intact Bluetooth car kit with CSR BlueCore5 MCU, MEMS microphone, Class D
-speaker amplifier, status LEDs, visor clip mount, and silicone button membrane
-with light pipes.
-
-**Best use — keep as a complete unit.** More valuable intact than as parts:
-
-- **Bluetooth serial bridge (SPP):** CSR BlueCore5 supports Serial Port Profile.
-  With custom firmware or AT commands, use as a wireless UART bridge for any
-  microcontroller project (range ~10m).
-- **Acoustic sensor:** The MEMS microphone + amplifier chain is already
-  noise-filtered for voice. Repurpose for acoustic drone detection — propeller
-  noise signatures are in the audible range. Feed audio to a RPi running
-  frequency analysis.
-- **Hands-free intercom:** Use as-is for workshop/garage intercom paired with a
-  phone.
-- **BT audio sink:** Stream audio from phone to any amplifier via the speaker
-  output pads.
-
-**Cross-project:** Bluetooth serial for IoT, acoustic monitoring, audio
-streaming, enclosure/UX design reference (button membrane + light pipes are
-excellent examples for 3D-printed housing design).
-
-### 12. Bluetooth Audio Receiver Module
-
-**Best use:** Build a portable Bluetooth speaker with a salvaged driver and
-amplifier. Pair with a power bank for a camping/workshop speaker.
-
-**Cross-project:** Audio streaming to any amplifier setup.
-
-### 13. LED Driver / Voltage Doubler
-
-**Best use:** Very limited. Toss.
+| 22 | NiMH Quick Charger | 1 | AA/AAA NiMH battery charger, mains powered | Working | Rechargeable battery maintenance | No | **Keep** |
+| 23 | BenQ Monitor (disassembled) | 1 | CCFL-backlit LCD, VGA+DVI, senseye scaler, 4H.L2E02.A34 PSU. **450V caps** | Unknown | Strip for caps, transformers, connectors. High-voltage learning | No | **Strip (learning + parts)** |
+| 24 | DStv Remote Control | 1 | MultiChoice/Explora IR remote, coloured A/B/C/D buttons | Working | IR protocol learning, IR receiver testing, spare remote | No | **Keep** |
+| 25 | HDMI Cable | 1 | Standard HDMI cable, appears full-size both ends | Working | Display connectivity for RPi, dev boards, any HDMI device | Yes — ground station display | **Keep** |
+| 26 | ARRIS DStv Decoder (F55525MC) | 1 | DStv Explora, 12V/2.5A, HDMI out, made in SA 2020. May contain 2.5" SATA HDD | Unknown | HDD salvage (if present), HDMI port practice, PSU analysis | No (locked to MultiChoice) | **Strip (HDD + learning)** |
+| 27a | Fridge Compressor | 1 | QD brand sealed compressor with start relay (Changlong), copper tubing | Working (needs gas) | Scrap copper (tubing), compressor motor for experimental air pump (no refrigerant) | No | **Strip (copper + learning)** |
+| 27b | Fridge Control Board | 1 | DIP controller IC (LCD(005C)), 3x mains relays, X2 safety cap, piezo buzzer, ribbon to LCD, electrolytic caps | Working | Mains relays (240V rated, reusable), X2 cap, piezo buzzer, DIP IC socket practice | No | **Strip (relays + buzzer)** |
+| 28 | Orion 320 Landline Telephone | 1 | PSTN desktop phone, speakerphone, speed-dial, LCD display area | Unknown | Keypad matrix learning, speaker/mic salvage, handset cord (RJ-9 curly cable) | No | **Strip (learning)** |
+| 29 | SPI ATX-250GT Power Supply | 1 | Sparkle Power 250W ATX PSU. +3.3V/14A, +5V/25A, +12V, mains input | Unknown | **Multi-voltage bench supply** (3.3V, 5V, 12V, -12V simultaneously), high current, standard ATX connector | Yes — bench power for all projects | **Keep (test first)** |
 
 ---
 
@@ -201,21 +75,44 @@ amplifier. Pair with a power bank for a camping/workshop speaker.
 
 | Project | Useful Components |
 |---------|-------------------|
-| **Rooivalk Drone (Paths A/B/C)** | #1 (ground station), #3 (controller), #6 (field power), #7 (telemetry), #11 (acoustic detection), #14 (buzzer), #19 (4G field link) |
+| **Rooivalk Drone (Paths A/B/C)** | #1 (ground station), #3 (controller), #6 (field power), #7 (telemetry), #11 (acoustic detection), #14 (buzzer), #19 (4G field link), #25 (HDMI), #29 (bench PSU) |
 | **Ground Rover / Robotics** | #4a (motor controller), #4c (hub motors), #3 (PS4 controller), #4d (MOSFETs) |
-| **IoT / Smart Home** | #7 (WiFi nodes), #9 (relay switching), #5 (bench power), #10 (buttons), #11 (BT serial bridge) |
-| **Networking / Lab** | #1 (OpenWrt router), #2 (backup/antenna donor), #17 (ZyXEL switch), #19 (4G LTE), #20a (Vodafone backup) |
+| **IoT / Smart Home** | #7 (WiFi nodes), #9 (relay), #5 (bench power), #10 (buttons), #11 (BT serial bridge), #27b (mains relays) |
+| **Networking / Lab** | #1 (OpenWrt), #2 (backup), #17 (ZyXEL switch), #19 (4G LTE), #20a (Vodafone) |
 | **Audio / Media** | #11 (Parrot BT kit), #12 (BT audio receiver) |
-| **EV / High-Power Builds** | #4a (BLDC controller), #4c (hub motors), #4d (power MOSFETs), #4e (current shunts) |
-| **General Prototyping** | #14 (piezo buzzer), #5 (5V supply), #6 (boost converter), #10 (button), #4e-g (harvested parts), #21 (PSUs), #22 (charger) |
-| **Toss Pile** | #8 (56K modem), #13 (LED driver), #15 (washer panel), #16 (T-Con), #18 (D-Link DSL), #20b (dupe Vodafone), #23 (BenQ monitor) |
+| **EV / High-Power Builds** | #4a (BLDC controller), #4c (hub motors), #4d (MOSFETs), #4e (shunts) |
+| **Bench / Power** | #29 (ATX PSU — top priority), #5 (5V USB), #6 (boost converter), #21 (wall-warts), #22 (charger) |
+| **General Prototyping** | #14 (buzzer), #10 (button), #4e-g (harvested parts), #24 (IR remote), #27b (relays, buzzer) |
+| **Learning / Stripping Practice** | #8 (modem), #15 (washer panel), #16 (T-Con), #18 (D-Link), #20b (Vodafone dupe), #23 (BenQ), #26 (decoder), #27 (fridge), #28 (phone) |
+
+---
+
+## Strip Priority Order
+
+For the dedicated disassembly person, work through in this order:
+
+| Priority | Item | Why First | Key Parts to Recover |
+|----------|------|-----------|---------------------|
+| 1 | #4b Hoverboard Board B | Highest-value components | MOSFETs, current shunts, caps, JST-XH connectors |
+| 2 | #27b Fridge Control Board | Easy through-hole, useful parts | 3x mains relays, piezo buzzer, X2 safety cap |
+| 3 | #26 ARRIS DStv Decoder | Check for HDD first | 2.5" SATA HDD (if present), heatsinks |
+| 4 | #23 BenQ Monitor PSU | **Discharge 450V caps first!** | Large electrolytics, transformers, connectors |
+| 5 | #20b Vodafone H 500-s | Practice + antenna salvage | WiFi antennas, heatsinks, RJ-45 jacks |
+| 6 | #18 D-Link DSL-2640U | SMD practice | RJ-45 jacks, LEDs, learning |
+| 7 | #28 Orion 320 Telephone | Through-hole + keypad | Keypad matrix, speaker, mic, handset cord |
+| 8 | #16 LG T-Con Board | QFP hot-air practice | SMD rework skill building |
+| 9 | #15 Washing Machine Panel | Basic desoldering practice | Rocker switches (non-standard but practice) |
+| 10 | #8 56K Modem Card | Mini-PCIe teardown | RJ-11 jack, SMD practice |
+| 11 | #27a Fridge Compressor | Last — heavy, messy | Copper tubing, start relay, motor windings |
 
 ---
 
 ## Storage Recommendations
 
-- **Keep assembled:** #4a (intact hoverboard board — do not strip), #11 (Parrot kit — more valuable intact)
-- **Anti-static bag:** #7 (WiFi module), #12 (BT module), #4d-g (harvested hoverboard parts)
-- **Labelled bin:** #14 (buzzer), #9 (relay), #10 (button), #6 (boost converter), #21 (tested PSUs)
-- **Shelf/rack:** #1 (Cudy router), #2 (old router), #3 (PS4 controller), #4c (hub motors), #17 (ZyXEL), #19 (Huawei 4G), #20a (Vodafone), #22 (NiMH charger)
-- **E-waste recycling:** #8 (56K modem), #13 (LED driver), #15 (washer panel), #16 (T-Con), #18 (D-Link DSL), #20b (dupe Vodafone), #23 (BenQ — **discharge 450V caps first**), RC toy board (after buzzer removed)
+- **Keep assembled:** #4a (hoverboard board A), #11 (Parrot kit), #1 (Cudy), #3 (PS4), #19 (Huawei 4G)
+- **Anti-static bag:** #7 (WiFi module), #12 (BT module), #4d-g (harvested parts)
+- **Labelled bin:** #14 (buzzer), #9 (relay), #10 (button), #6 (boost converter), #24 (remote), #25 (HDMI)
+- **Shelf/rack:** #2 (old router), #4c (hub motors), #17 (ZyXEL), #20a (Vodafone), #22 (charger), #29 (ATX PSU)
+- **Test with adapters (#21):** #17 (needs 12V), #19 (needs 12V), #29 (needs mains)
+- **Stripping queue:** #4b, #27b, #26, #23, #20b, #18, #28, #16, #15, #8, #27a
+- **True e-waste (nothing to strip):** #13 (LED driver — too small/unmarked)

--- a/apps/docs/docs/research/spare-parts-bin.md
+++ b/apps/docs/docs/research/spare-parts-bin.md
@@ -3,34 +3,44 @@
 Catalogue of salvaged components identified from around the workshop. Assessed
 for usefulness across **all projects** — not just Phoenix Rooivalk drone builds.
 
+> **Note:** The original toy quadcopter (X8-class, 320mm diagonal) documented in
+> the hardware teardown has been stolen. Upgrade paths A/B/C will require a new
+> donor airframe or proceed directly to Path B (new frame build).
+
 **Legend:**
 - **Rooivalk** = Drone upgrade paths (A/B/C) and counter-UAS platform
 - **IoT/Smart Home** = ESP32, Tuya, Home Assistant, sensor networks
 - **Networking** = Ground stations, mesh networks, lab infrastructure
 - **Audio/Media** = Bluetooth speakers, media projects
+- **Robotics/EV** = Ground vehicles, rovers, electric builds
 - **General Electronics** = Bench tools, prototyping, learning
 
 ---
 
 ## Master Inventory Table
 
-| # | Component | Description | Condition | Useful For | Rooivalk? | Keep/Toss |
-|---|-----------|-------------|-----------|------------|-----------|-----------|
-| 1 | Cudy WR3000 WiFi 6 Router | MediaTek MT7981B SoC, WiFi 6, dual-band, OpenWrt compatible | Working | Ground station networking, mesh relay, OpenWrt lab, VPN endpoint | Yes — ground station | **Keep** |
-| 2 | Older MT7615DN WiFi Router | MediaTek MT7615DN chipset, 2.4/5GHz, larger form factor | Working | Backup router, 2.4GHz antenna donor, OpenWrt experiments | Marginal — antenna salvage | **Keep (antennas)** |
-| 3 | PS4 DualShock 4 (JDM-011) | Sony CUH-ZCT1U controller, Bluetooth + USB, analog sticks, IMU | Working | Gaming, DIY RC controller (analog sticks), Bluetooth HID input | Yes — manual override controller | **Keep** |
-| 4 | RC Toy Motor Controller PCB | Blue PCB from cheap RC car, H-bridge brushed motor driver, piezo buzzer | Working | Piezo buzzer salvage, learning H-bridge circuits | No | **Keep (buzzer only)** |
-| 5 | USB Wall Charger PCB | 5V USB-A output, mains AC input, bare PCB (no enclosure) | Working | Bench 5V supply, powering dev boards, phone charging | Indirect — bench power | **Keep** |
-| 6 | 1S-to-5V USB Boost Converter | Small PCB, single-cell LiPo input, 5V USB output, ~1A | Working | Portable RPi power testing, field USB charging from LiPo | Yes — field power for companion computer | **Keep** |
-| 7 | Tuya WR3E WiFi Module | RTL8710BN-based, 2.4GHz WiFi, reflashable (LibreTiny/ESPHome) | Working | IoT sensor nodes, WiFi telemetry bridge, smart home devices | Yes — lightweight WiFi telemetry | **Keep** |
-| 8 | Laptop 56K Modem Card | Mini-PCIe dial-up modem, RJ-11 jack | Unknown | Nothing — obsolete technology, no modern use | No | **Toss** |
-| 9 | Fanhar Relay Module | Single-channel 5V relay, opto-isolated, screw terminals | Working | Home automation, irrigation control, power switching circuits | No (too heavy for drone) | **Keep** |
-| 10 | Tactile Push Button Breakout | Small PCB with single tactile switch, 2-pin header | Working | Prototyping reset/boot buttons, breadboard projects | Marginal — parts bin filler | **Keep** |
-| 11 | Parrot Minikit+ Main Board (MPP_MB_07) | Bluetooth 2.1+EDR car kit, CSR BlueCore5 chipset, MEMS mic, speaker amp | Working | Bluetooth audio experiments, hands-free intercom, DSP learning | No | **Keep (learning)** |
-| 12 | Parrot Minikit+ Clip/Mount Assembly | Visor clip mechanism with speaker grille and mic housing | Working | Enclosure/mount reference for 3D printing projects | No | **Keep** |
-| 13 | Parrot Minikit+ Button Membrane + Light Pipe | Silicone button pad with integrated light guides for status LEDs | Working | UI reference for custom enclosures, LED light pipe examples | No | **Keep (reference)** |
-| 14 | Bluetooth Audio Receiver Module | Small PCB, BT audio sink, 3.5mm or solder pad output | Working | Portable Bluetooth speaker builds, audio streaming to amp | No | **Keep** |
-| 15 | LED Driver / Voltage Doubler Tiny PCB | Charge-pump circuit, ~10mm PCB, likely white LED backlight driver | Unknown | Very limited — niche LED driving only | No | **Toss** |
+| # | Component | Qty | Description | Condition | Useful For | Rooivalk? | Keep/Toss |
+|---|-----------|-----|-------------|-----------|------------|-----------|-----------|
+| 1 | Cudy WR3000 WiFi 6 Router | 1 | MediaTek MT7981B SoC, WiFi 6, dual-band, OpenWrt compatible | Working | Ground station networking, mesh relay, OpenWrt lab, VPN endpoint | Yes — ground station | **Keep** |
+| 2 | Older MT7615DN WiFi Router | 1 | MediaTek MT7615DN chipset, 2.4/5GHz, larger form factor | Working | Backup router, 2.4GHz antenna donor, OpenWrt experiments | Marginal — antenna salvage | **Keep (antennas)** |
+| 3 | PS4 DualShock 4 (JDM-011) | 1 | Sony CUH-ZCT1U controller, Bluetooth + USB, analog sticks, IMU | Working | Gaming, DIY RC controller (analog sticks), Bluetooth HID input | Yes — manual override controller | **Keep** |
+| 4a | Hoverboard Controller Board (intact) | 1 | Blue PCB, dual 3-phase BLDC driver, STM32/GD32 MCU, power MOSFETs, hall sensor inputs, JST-XH connectors, 36V rated | Working | Dual BLDC motor controller — robot platform, electric go-kart, belt grinder, CNC spindle driver. Reflashable with open-source FOC firmware | Yes — ground rover platform | **Keep (intact)** |
+| 4b | Hoverboard Controller Board (harvest) | 1 | Same as 4a — designated for component salvage | Working | MOSFET harvesting, current sense resistors, capacitors, connectors | Parts donor | **Keep (harvest)** |
+| 4c | Hoverboard Hub Motors | 2 | 36V 250-350W brushless DC hub motors, ~6.5" wheel with tyre | Working | Electric skateboard, go-kart, robot rover, belt grinder, lathe spindle. Most valuable items in the bin (~R500+ each) | Yes — ground rover | **Keep** |
+| 4d | Hoverboard Power MOSFETs (from 4b) | 6-8 | CLN89 or similar N-channel D-PAK, 60-100V 30A+ rated | Harvestable | High-current switching: motor drivers, DC-DC converters, power supplies, e-bike controllers | Yes — custom ESC builds | **Harvest** |
+| 4e | Hoverboard Current Sense Resistors (from 4b) | 4+ | R004/R010 low-ohm precision shunt resistors | Harvestable | Motor/battery current monitoring on any power project | Yes — current sensing | **Harvest** |
+| 4f | Hoverboard Electrolytic Caps (from 4b) | 2-4 | 220uF 35-50V rated | Harvestable | Power supply filtering on any 12-36V project | General use | **Harvest** |
+| 4g | Hoverboard JST-XH Connectors (from 4b) | 6+ | 2.54mm pitch, multi-pin, through-hole, white | Harvestable | Reusable connectors for any project wiring | General use | **Harvest** |
+| 5 | USB Wall Charger PCB | 1 | 5V USB-A output, mains AC input, bare PCB (no enclosure) | Working | Bench 5V supply, powering dev boards, phone charging | Indirect — bench power | **Keep** |
+| 6 | 1S-to-5V USB Boost Converter | 1 | Small PCB, single-cell LiPo input, 5V USB output, ~1A | Working | Portable RPi power testing, field USB charging from LiPo | Yes — field power for companion computer | **Keep** |
+| 7 | Tuya WR3E WiFi Module | 1 | RTL8710BN-based, 2.4GHz WiFi, reflashable (LibreTiny/ESPHome) | Working | IoT sensor nodes, WiFi telemetry bridge, smart home devices | Yes — lightweight WiFi telemetry | **Keep** |
+| 8 | Laptop 56K Modem Card | 1 | Mini-PCIe dial-up modem, RJ-11 jack | Unknown | Nothing — obsolete technology, no modern use | No | **Toss** |
+| 9 | Fanhar Relay Module | 1 | Single-channel 5V relay, opto-isolated, screw terminals | Working | Home automation, irrigation control, power switching circuits | No (too heavy for drone) | **Keep** |
+| 10 | Tactile Push Button Breakout | 1 | Small PCB with single tactile switch, 2-pin header | Working | Prototyping reset/boot buttons, breadboard projects | Marginal — parts bin filler | **Keep** |
+| 11 | Parrot Minikit+ Complete Unit (MPP_MB_07) | 1 | Bluetooth 2.1+EDR car kit — CSR BlueCore5 MCU, MEMS mic, Class D speaker amp, status LEDs, clip mount, button membrane with light pipes. Fully intact | Working | Bluetooth audio sink/source, hands-free intercom, voice-activated trigger, BT serial bridge (SPP profile), MEMS mic for acoustic detection | Yes — acoustic drone detection sensor, BT serial bridge | **Keep** |
+| 12 | Bluetooth Audio Receiver Module | 1 | Small PCB, BT audio sink, 3.5mm or solder pad output | Working | Portable Bluetooth speaker builds, audio streaming to amp | No | **Keep** |
+| 13 | LED Driver / Voltage Doubler Tiny PCB | 1 | Charge-pump circuit, ~10mm PCB, likely white LED backlight driver | Unknown | Very limited — niche LED driving only | No | **Toss** |
+| 14 | Piezo Buzzer (from RC toy board) | 1 | Through-hole piezo disc, salvaged from toy car controller | Working | Lost-model alarm, status beeper, audible alerts | Yes — lost-model buzzer | **Keep** |
 
 ---
 
@@ -63,13 +73,39 @@ touchpad.
 
 **Cross-project:** Gaming, robotics control, any project needing analog input.
 
-### 4. RC Toy Motor Controller PCB
+### 4a-g. Hoverboard Components (x2 boards, x2 hub motors)
 
-**Best use:** The piezo buzzer is worth desoldering — useful as a lost-model
-alarm or status beeper on any build. The H-bridge driver IC is too weak and
-undocumented for reuse.
+Salvaged from two self-balancing scooters (hoverboards). These are **the most
+valuable items in the entire spare parts bin**.
 
-**Cross-project:** Electronics learning, piezo salvage.
+**Board A (keep intact):** Flash with open-source FOC firmware
+(e.g. [EFeru/hoverboard-firmware-hack-FOC](https://github.com/EFeru/hoverboard-firmware-hack-FOC)).
+This gives you a ready-made dual BLDC motor controller with hall sensor inputs,
+current sensing, UART/I2C control interface, and 36V power handling. Perfect
+base for a ground rover, electric go-kart, or autonomous robot platform.
+
+**Board B (harvest):** Desolder the power MOSFETs (CLN89 or similar — D-PAK
+package, easy with hot air or wide chisel tip). These are 60-100V, 30A+
+N-channel FETs — genuinely expensive to buy individually and useful for any
+high-current project. Also harvest the R004/R010 current sense resistors
+(precision shunts, annoying to source), the 220uF caps, and the JST-XH
+connectors.
+
+**Hub motors (x2):** 36V 250-350W BLDC hub motors with integrated tyres.
+Worth R500+ each new. Use cases: robot rover, electric skateboard, belt grinder,
+lathe spindle, go-kart, wheelchair conversion, conveyor drive.
+
+**Rooivalk relevance:** Not for the drone itself (way too heavy), but highly
+relevant for a ground-based counter-UAS rover platform or autonomous patrol
+vehicle. Combined with the PS4 controller (#3) and a RPi, you have the bones of
+a remote-controlled ground station on wheels.
+
+### 14. Piezo Buzzer (salvaged from RC toy board)
+
+**Best use:** Lost-model alarm or status beeper on any drone build. Desolder
+from the good RC toy board (5 seconds, two wires). Toss the rest of that board.
+
+**Cross-project:** Any project needing audible feedback.
 
 ### 5. USB Wall Charger PCB
 
@@ -111,26 +147,40 @@ project that needs to toggle mains or high-current DC loads.
 **Best use:** Breadboard prototyping. Keep in the parts bin for when you need a
 quick button input on any project.
 
-### 11-13. Parrot Minikit+ Components
+### 11. Parrot Minikit+ Complete Unit
 
-**Best use:** The CSR BlueCore5 Bluetooth chipset is a capable BT 2.1 audio
-device. The MEMS microphone and speaker amplifier could be reused in an
-intercom or audio monitoring project. The clip mount and button membrane are
-good physical design references if you're 3D printing enclosures.
+Fully intact Bluetooth car kit with CSR BlueCore5 MCU, MEMS microphone, Class D
+speaker amplifier, status LEDs, visor clip mount, and silicone button membrane
+with light pipes.
 
-**Cross-project:** Bluetooth audio experiments, enclosure design reference.
+**Best use — keep as a complete unit.** More valuable intact than as parts:
 
-### 14. Bluetooth Audio Receiver Module
+- **Bluetooth serial bridge (SPP):** CSR BlueCore5 supports Serial Port Profile.
+  With custom firmware or AT commands, use as a wireless UART bridge for any
+  microcontroller project (range ~10m).
+- **Acoustic sensor:** The MEMS microphone + amplifier chain is already
+  noise-filtered for voice. Repurpose for acoustic drone detection — propeller
+  noise signatures are in the audible range. Feed audio to a RPi running
+  frequency analysis.
+- **Hands-free intercom:** Use as-is for workshop/garage intercom paired with a
+  phone.
+- **BT audio sink:** Stream audio from phone to any amplifier via the speaker
+  output pads.
+
+**Cross-project:** Bluetooth serial for IoT, acoustic monitoring, audio
+streaming, enclosure/UX design reference (button membrane + light pipes are
+excellent examples for 3D-printed housing design).
+
+### 12. Bluetooth Audio Receiver Module
 
 **Best use:** Build a portable Bluetooth speaker with a salvaged driver and
 amplifier. Pair with a power bank for a camping/workshop speaker.
 
 **Cross-project:** Audio streaming to any amplifier setup.
 
-### 15. LED Driver / Voltage Doubler
+### 13. LED Driver / Voltage Doubler
 
-**Best use:** Very limited. Charge-pump voltage doublers are cheap and
-application-specific. Not worth designing around.
+**Best use:** Very limited. Toss.
 
 ---
 
@@ -138,18 +188,21 @@ application-specific. Not worth designing around.
 
 | Project | Useful Components |
 |---------|-------------------|
-| **Rooivalk Drone (Paths A/B/C)** | #1 (ground station), #3 (controller), #6 (field power), #7 (telemetry) |
-| **IoT / Smart Home** | #7 (WiFi nodes), #9 (relay switching), #5 (bench power), #10 (buttons) |
+| **Rooivalk Drone (Paths A/B/C)** | #1 (ground station), #3 (controller), #6 (field power), #7 (telemetry), #11 (acoustic detection), #14 (buzzer) |
+| **Ground Rover / Robotics** | #4a (motor controller), #4c (hub motors), #3 (PS4 controller), #4d (MOSFETs) |
+| **IoT / Smart Home** | #7 (WiFi nodes), #9 (relay switching), #5 (bench power), #10 (buttons), #11 (BT serial bridge) |
 | **Networking / Lab** | #1 (OpenWrt router), #2 (backup/antenna donor) |
-| **Audio / Media** | #11 (Bluetooth car kit), #14 (BT audio receiver) |
-| **General Prototyping** | #4 (piezo buzzer), #5 (5V supply), #6 (boost converter), #10 (button) |
-| **Toss Pile** | #8 (56K modem), #15 (LED driver) |
+| **Audio / Media** | #11 (Parrot BT kit), #12 (BT audio receiver) |
+| **EV / High-Power Builds** | #4a (BLDC controller), #4c (hub motors), #4d (power MOSFETs), #4e (current shunts) |
+| **General Prototyping** | #14 (piezo buzzer), #5 (5V supply), #6 (boost converter), #10 (button), #4e-g (harvested parts) |
+| **Toss Pile** | #8 (56K modem), #13 (LED driver) |
 
 ---
 
 ## Storage Recommendations
 
-- **Anti-static bag:** #7 (WiFi module), #11 (Parrot board), #14 (BT module)
-- **Labelled bin:** #4 (buzzer), #9 (relay), #10 (button), #6 (boost converter)
-- **Shelf/rack:** #1 (Cudy router), #2 (old router), #3 (PS4 controller)
-- **Recycling:** #8 (modem), #15 (LED driver)
+- **Keep assembled:** #4a (intact hoverboard board — do not strip), #11 (Parrot kit — more valuable intact)
+- **Anti-static bag:** #7 (WiFi module), #12 (BT module), #4d-g (harvested hoverboard parts)
+- **Labelled bin:** #14 (buzzer), #9 (relay), #10 (button), #6 (boost converter)
+- **Shelf/rack:** #1 (Cudy router), #2 (old router), #3 (PS4 controller), #4c (hub motors)
+- **E-waste recycling:** #8 (56K modem), #13 (LED driver), RC toy board (after buzzer removed)

--- a/apps/docs/docs/research/spare-parts-decisions.md
+++ b/apps/docs/docs/research/spare-parts-decisions.md
@@ -454,6 +454,215 @@ The board itself is lead-free and RoHS — safe for e-waste recycling.
 
 ---
 
+## SPD-17: ZyXEL CB71 Gateway (EMG2926-T50C)
+
+**Status:** Keep — test first
+
+> ZyXEL dual-band WiFi 5 gateway, model EMG2926-T50C. 4x Gigabit LAN (yellow)
+> + 1x WAN (blue), on/off switch, 12V/1.5A barrel jack. ISP-provided unit.
+
+**Use for:**
+- 4-port Gigabit managed switch — even without OpenWrt, the LAN ports work as
+  a basic switch for connecting multiple wired devices at a workbench
+- Backup WiFi access point if configured in AP mode
+- VLAN-capable if factory firmware supports it (some ZyXEL units do)
+- Test network isolation — use as a separate subnet for testing IoT devices
+
+**Scrap for:**
+- N/A — more valuable intact as a working network device
+
+**Toss?** No, provided it works. Test with a 12V PSU (check your adapter pile,
+SPD-21). If it doesn't boot or has a locked/bricked firmware, then toss.
+
+**Decision:** Keep. Test with power adapter. Use as a 4-port Gigabit switch or
+backup AP at the workbench. Not critical, but free and useful.
+
+---
+
+## SPD-18: D-Link DSL-2640U
+
+**Status:** Toss
+
+> D-Link ADSL2+ modem/router, model DSL-2640U (RSL2640UEBRU.C2E), FW v2.01,
+> 802.11n only. Black plastic enclosure.
+
+**Use for:**
+- Nothing. ADSL requires a phone line (PSTN/DSL) which you almost certainly
+  don't have. The WiFi is 2.4GHz 802.11n only (slow). Even as an OpenWrt
+  device, the AR7-based chipset has very limited RAM and no meaningful
+  community support.
+
+**Scrap for:**
+- Nothing worth the effort. Internal PCB has a low-end Memory-limited SoC,
+  small RAM, and no reusable components.
+
+**Toss?** **Yes.** Obsolete access technology, weak hardware, no reuse path.
+
+**Decision:** E-waste recycling bin.
+
+---
+
+## SPD-19: Huawei B315s-936 (4G LTE Router)
+
+**Status:** Keep — high value
+
+> Huawei B315s-936, LTE Cat 4 (150Mbps down / 50Mbps up), SIM card slot,
+> WiFi 802.11n, Ethernet LAN, 12V/1A input. Has IMEI for network registration.
+
+**Use for:**
+- **Primary use: 4G field data link.** Insert a SIM card and you have instant
+  internet anywhere with cellular coverage. Perfect for field testing the ground
+  station, uploading telemetry data, or remote access to equipment.
+- Backup WAN for home network (failover if fibre goes down)
+- Portable hotspot for workshops, demos, or site visits
+- Remote monitoring — leave it at a location with power and a SIM, SSH in
+  over 4G to check sensors/cameras
+
+**Scrap for:**
+- N/A — far too valuable as a working 4G router. Replacement cost R500-800.
+
+**Toss?** Absolutely not. A working 4G LTE router with SIM slot is one of the
+most useful networking devices you can have.
+
+**Decision:** Keep intact. Get a data-only SIM (Telkom or Rain) for field use.
+This becomes a core part of the ground station networking stack alongside the
+Cudy WR3000.
+
+**Rooivalk relevance:** Direct. Provides internet connectivity at test sites
+where there's no WiFi. Enables remote telemetry upload, OTA firmware updates,
+and remote SSH access to the ground station.
+
+---
+
+## SPD-20a: Vodafone H 500-s (Keep Unit)
+
+**Status:** Keep one
+
+> Vodafone H 500-s, dual-band WiFi 5, 12V/2.5A, ISP-branded. Two identical
+> units — keep the one in better physical condition.
+
+**Use for:**
+- Backup router for home network
+- Isolated test network for IoT/security experiments
+- WiFi AP for workshop/garage
+
+**Scrap for:**
+- N/A — keep intact
+
+**Toss?** No (this unit). Keep the one with less physical damage and cleaner
+connectors.
+
+**Decision:** Keep the better-condition unit. Label it "backup". Low priority
+but costs nothing to store.
+
+---
+
+## SPD-20b: Vodafone H 500-s (Duplicate)
+
+**Status:** Toss
+
+**Use for:** Nothing — redundant duplicate of 20a.
+
+**Scrap for:** Nothing worth the effort. ISP router internals are application-
+specific SoCs with no reuse path.
+
+**Toss?** **Yes.** You don't need two identical ISP routers. One backup is
+enough.
+
+**Decision:** E-waste recycling bin.
+
+---
+
+## SPD-21: Wall-Wart Power Adapters (Assorted)
+
+**Status:** Keep — test and sort
+
+> ~6 mixed DC power adapters with SA 2-pin plugs, barrel jack outputs.
+> Expected voltages: 5V, 9V, 12V. Various current ratings.
+
+**Use for:**
+- Bench power supplies for routers (#17, #19, #20a all need 12V)
+- Dev board power: 5V for RPi/ESP32, 9V for Arduino Uno, 12V for LED strips
+- Any project needing a quick regulated DC source
+- Match adapters to orphaned devices (routers, chargers, etc.)
+
+**Scrap for:**
+- N/A — keep the working ones, toss the dead ones
+
+**Toss?** Toss any that are dead or have damaged cables. Keep all working ones
+with known voltages.
+
+**Action required:**
+1. Test each with a multimeter (measure output voltage under no load)
+2. Label each with voltage and current (e.g. "12V 1.5A")
+3. Match 12V adapters to the ZyXEL, Huawei, and Vodafone routers
+4. Keep a 5V adapter for bench use
+5. Toss any that are dead, have frayed cables, or have no measurable output
+
+**Decision:** Test, label, and keep working ones. Toss dead ones.
+
+---
+
+## SPD-22: NiMH Quick Charger
+
+**Status:** Keep
+
+> Mains-powered NiMH AA/AAA battery charger.
+
+**Use for:**
+- Maintaining rechargeable AA/AAA batteries for remotes, wireless mice,
+  sensors, flashlights
+- Cycling old NiMH cells to check remaining capacity
+
+**Scrap for:**
+- N/A — it's a charger, use it
+
+**Toss?** No. Rechargeable batteries save money long-term.
+
+**Decision:** Keep. Test with a set of NiMH cells to confirm it still charges.
+
+---
+
+## SPD-23: BenQ Monitor (Disassembled)
+
+**Status:** Toss — with safety precautions
+
+> Old BenQ CCFL-backlit LCD monitor, fully disassembled. Components:
+> - BenQ senseye scaler/controller board (VGA + DVI inputs)
+> - Power supply / CCFL inverter board (4H.L2E02.A34)
+> - LCD panel (unknown condition)
+> - FPC ribbon cables
+
+**Use for:**
+- Nothing. VGA and DVI are dead standards — no modern device outputs DVI, and
+  VGA adapters are clunky. CCFL backlights are obsolete (replaced by LED).
+  The resolution and response time will be poor by any modern standard. Not
+  suitable as a ground station display (no HDMI/DP).
+
+**Scrap for:**
+- **LCD panel** — could theoretically be driven with a universal LVDS controller
+  board (R100-150 on AliExpress), but you'd be spending money to create a
+  mediocre display with no backlight. Not worth it.
+- **Scaler board** — proprietary BenQ IC, no reuse.
+- **PSU/inverter board** — CCFL-specific transformers and topology. The large
+  electrolytic caps (100uF/450V, 160uF/450V) are the only "valuable" parts,
+  but they're dangerous and of marginal use.
+- **FPC ribbons** — panel-specific, no reuse.
+
+**Toss?** **Yes.** But **safely:**
+
+> **WARNING:** The PSU board contains 100uF/450V and 160uF/450V capacitors that
+> can hold lethal charge even when unplugged. Before handling or recycling:
+> 1. Verify no charge with a multimeter across cap terminals (should read <1V)
+> 2. If any voltage: discharge through a 10kΩ resistor (not a screwdriver — that
+>    can damage the cap and spark)
+> 3. Once confirmed discharged, safe to handle and recycle
+
+**Decision:** Discharge caps, then e-waste recycling bin. All boards and panel.
+Nothing salvageable.
+
+---
+
 ## Summary of Decisions
 
 | # | Component | Decision | Action Required |
@@ -476,3 +685,11 @@ The board itself is lead-free and RoHS — safe for e-waste recycling.
 | 14 | Piezo Buzzer | Keep | Desolder from RC board, toss board |
 | 15 | Washing Machine Button Panel | **Toss** | E-waste bin — proprietary form factor |
 | 16 | LG TV T-Con Board | **Toss** | E-waste bin — zero salvage value |
+| 17 | ZyXEL CB71 Gateway | Keep (test first) | Test with 12V PSU, use as switch/AP |
+| 18 | D-Link DSL-2640U | **Toss** | E-waste bin — ADSL obsolete |
+| 19 | Huawei B315s-936 (4G LTE) | **Keep** | Get data SIM, use as field link |
+| 20a | Vodafone H 500-s (keep) | Keep (low priority) | Backup router |
+| 20b | Vodafone H 500-s (dupe) | **Toss** | E-waste bin — redundant |
+| 21 | Wall-Wart Adapters (~6) | Keep (tested ones) | Test, label voltage/current, toss dead |
+| 22 | NiMH Quick Charger | Keep | Test with cells |
+| 23 | BenQ Monitor (disassembled) | **Toss** | **Discharge 450V caps first**, then e-waste |

--- a/apps/docs/docs/research/spare-parts-decisions.md
+++ b/apps/docs/docs/research/spare-parts-decisions.md
@@ -14,7 +14,14 @@ Each entry follows this structure:
 - **Use for:** Primary intended use case(s)
 - **Scrap for:** Components worth harvesting if the unit itself isn't kept whole
 - **Toss?:** Yes/no and why
+- **Learning value:** What can be learned from stripping/studying this item
 - **Decision:** Final verdict with reasoning
+
+> **Philosophy:** A dedicated person handles all disassembly — labour is free.
+> Nothing is "not worth the effort." If a component is useful once removed,
+> strip it. If the board teaches something about electronics, strip it for
+> learning. Only truly empty items (unmarked, too small, nothing to learn) get
+> tossed outright.
 
 ---
 
@@ -227,19 +234,25 @@ use case. Most likely deployment: smart home sensor or telemetry bridge.
 
 ## SPD-08: Laptop 56K Modem Card
 
-**Status:** Toss
+**Status:** Strip (learning) — low priority
 
 **Use for:**
-- Nothing. Dial-up is extinct. No PSTN line to connect to. No software supports
-  it. Cannot be repurposed as a different interface.
+- Nothing functional. Dial-up is extinct.
 
 **Scrap for:**
-- Nothing worth the effort. The RJ-11 jack is obsolete. The DAA (data access
-  arrangement) IC is application-specific. No useful passives.
+- RJ-11 jack — niche but free
+- Mini-PCIe connector — reference for form factor
+- SMD passives — practice material
 
-**Toss?** **Yes.** Zero use cases across any project category.
+**Learning value:** Mini-PCIe card teardown. Good intro to identifying DAA
+(data access arrangement) circuits, line coupling transformers, and mixed-signal
+PCB layout. Teaches the difference between digital and analog sections on a
+single board.
 
-**Decision:** E-waste recycling bin.
+**Toss?** No — strip for learning practice, then toss the bare board.
+
+**Decision:** Low-priority strip job. Study the PCB layout, practice SMD
+identification, then recycle.
 
 ---
 
@@ -389,31 +402,28 @@ removing its buzzer since it may be damaged.
 
 ## SPD-15: Panasonic Washing Machine Button Panel PCB
 
-**Status:** Toss
+**Status:** Strip (learning) — low priority
 
 > Part number A4274008084. Brown phenolic PCB with three rocker/push switches,
 > ribbon cable, R13x resistors, CN connectors. From a Panasonic washing machine
 > control panel.
 
 **Use for:**
-- Nothing practical. The switches are a proprietary form factor moulded to fit
-  a specific washing machine fascia. They won't mount in any standard enclosure
-  or breadboard setup.
+- Nothing practical. The switches are proprietary form factor.
 
 **Scrap for:**
-- The rocker switches — but they're non-standard shape/mounting, designed for a
-  specific plastic housing that you don't have. Standard panel-mount rockers are
-  R5 each.
-- SMD resistors (R13x series) — generic, not worth desoldering from phenolic
-  board.
-- Ribbon cable — proprietary pitch and length. Useless without the matching
-  connector on the main washer board.
+- Rocker switches — non-standard mounting but could work in a custom 3D-printed
+  panel if someone designs around them
+- SMD resistors (R13x series) — generic, good desoldering practice targets
 
-**Toss?** **Yes.** Proprietary form factor throughout. Even the switches can't
-be reused without their matching housing. No components worth the desoldering
-effort.
+**Learning value:** Basic through-hole and SMD desoldering practice on a simple,
+low-density phenolic board. Good starter board — no fine-pitch ICs, no danger.
+Teaches connector identification and ribbon cable pin-counting.
 
-**Decision:** E-waste recycling bin. Don't strip anything.
+**Toss?** No — use as a beginner desoldering practice board, then toss.
+
+**Decision:** Low-priority learning strip. Good first board for someone
+learning to desolder.
 
 ---
 
@@ -446,11 +456,16 @@ effort.
 - **SMD passives** — dozens of tiny resistors and caps, all generic and not
   worth harvesting.
 
-**Toss?** **Yes.** Every component on this board is either proprietary
-(the ICs, connectors) or too cheap to justify desoldering (passives, caps).
-The board itself is lead-free and RoHS — safe for e-waste recycling.
+**Learning value:** High. Hot-air QFP desoldering practice on real production
+hardware. Teaches LVDS signal routing, FPC connector handling, and how display
+timing controllers work. The serial data/clock (SDAT/SCLK) lines are a good
+example of high-speed digital PCB layout.
 
-**Decision:** E-waste recycling bin. Zero salvage value.
+**Toss?** No — use as an intermediate SMD rework practice board, then toss.
+
+**Decision:** Strip for QFP hot-air desoldering practice. The ICs themselves are
+useless, but the skill of cleanly removing a 128+ pin QFP package is valuable.
+Also good practice for FPC connector removal.
 
 ---
 
@@ -481,24 +496,31 @@ backup AP at the workbench. Not critical, but free and useful.
 
 ## SPD-18: D-Link DSL-2640U
 
-**Status:** Toss
+**Status:** Strip (learning) — low priority
 
 > D-Link ADSL2+ modem/router, model DSL-2640U (RSL2640UEBRU.C2E), FW v2.01,
 > 802.11n only. Black plastic enclosure.
 
 **Use for:**
-- Nothing. ADSL requires a phone line (PSTN/DSL) which you almost certainly
-  don't have. The WiFi is 2.4GHz 802.11n only (slow). Even as an OpenWrt
-  device, the AR7-based chipset has very limited RAM and no meaningful
-  community support.
+- Nothing functional. ADSL-only, ancient hardware.
 
 **Scrap for:**
-- Nothing worth the effort. Internal PCB has a low-end Memory-limited SoC,
-  small RAM, and no reusable components.
+- RJ-45 Ethernet jacks (with built-in magnetics) — reusable in custom
+  Ethernet projects
+- LEDs (front panel indicators) — standard 3mm through-hole
+- PCB antenna (if present) — 2.4GHz antenna trace reference
+- Small heatsink (if present)
 
-**Toss?** **Yes.** Obsolete access technology, weak hardware, no reuse path.
+**Learning value:** Complete router teardown. Learn to identify: SoC, RAM, flash
+storage, Ethernet PHY, ADSL line driver, RF section, voltage regulators. Good
+practice for tracing power rails and signal paths. Could attempt UART serial
+console access (most D-Link routers have UART test points) as a learning
+exercise.
 
-**Decision:** E-waste recycling bin.
+**Toss?** No — strip for learning, recover RJ-45 jacks, then toss board.
+
+**Decision:** Low-priority strip. UART console hunting is a good embedded
+systems learning exercise. Keep the RJ-45 jacks.
 
 ---
 
@@ -559,17 +581,27 @@ but costs nothing to store.
 
 ## SPD-20b: Vodafone H 500-s (Duplicate)
 
-**Status:** Toss
+**Status:** Strip (learning)
 
-**Use for:** Nothing — redundant duplicate of 20a.
+**Use for:** Nothing functional — redundant duplicate of 20a.
 
-**Scrap for:** Nothing worth the effort. ISP router internals are application-
-specific SoCs with no reuse path.
+**Scrap for:**
+- WiFi antennas (internal PCB or wire antennas, 2.4GHz + 5GHz) — reusable
+- Heatsinks (SoC/WiFi chip heatsinks) — always useful
+- RJ-45 jacks (with magnetics) — reusable
+- Flash chip — if SPI NOR, could be interesting to dump/read
+- Shielding cans — useful for RF projects
 
-**Toss?** **Yes.** You don't need two identical ISP routers. One backup is
-enough.
+**Learning value:** High. Full ISP router teardown with a known-good reference
+unit (20a) to compare against. Learn to identify: WiFi chipset, RAM (DDR),
+SPI flash, power management ICs, antenna design (PCB trace vs wire). Try
+reading the SPI flash contents as a data forensics exercise. Compare PCB
+layout to the D-Link (#18) to understand different router architectures.
 
-**Decision:** E-waste recycling bin.
+**Toss?** No — strip for antennas, heatsinks, jacks, and learning.
+
+**Decision:** Strip. More advanced teardown than the D-Link — dual-band WiFi,
+better components. Keep antennas and heatsinks. Good learning exercise.
 
 ---
 
@@ -634,32 +666,242 @@ with known voltages.
 > - FPC ribbon cables
 
 **Use for:**
-- Nothing. VGA and DVI are dead standards — no modern device outputs DVI, and
-  VGA adapters are clunky. CCFL backlights are obsolete (replaced by LED).
-  The resolution and response time will be poor by any modern standard. Not
-  suitable as a ground station display (no HDMI/DP).
+- Nothing as a complete monitor. VGA/DVI are dead, CCFL is obsolete, no HDMI.
 
 **Scrap for:**
-- **LCD panel** — could theoretically be driven with a universal LVDS controller
-  board (R100-150 on AliExpress), but you'd be spending money to create a
-  mediocre display with no backlight. Not worth it.
-- **Scaler board** — proprietary BenQ IC, no reuse.
-- **PSU/inverter board** — CCFL-specific transformers and topology. The large
-  electrolytic caps (100uF/450V, 160uF/450V) are the only "valuable" parts,
-  but they're dangerous and of marginal use.
-- **FPC ribbons** — panel-specific, no reuse.
+- **100uF/450V and 160uF/450V electrolytic caps** — high-voltage caps useful
+  for power supply projects, Tesla coil experiments, or spares for other
+  monitor/PSU repairs
+- **CCFL inverter transformers (T801, T802)** — high-voltage transformers, good
+  for learning about flyback topology and HV generation
+- **Common-mode choke** — mains filter component, reusable in any PSU project
+- **Bridge rectifier** — standard, reusable
+- **Mains fuse holder + fuse** — always useful
+- **VGA/DVI connectors** — can be desoldered for custom cable or breakout
+  projects
+- **FPC ribbons** — panel-specific, no reuse
+- **LCD panel** — could be driven with universal LVDS board (R100-150) but not
+  worth spending money on
 
-**Toss?** **Yes.** But **safely:**
+**Learning value:** Very high. The PSU/inverter board teaches SMPS (switched-mode
+power supply) topology, mains safety, CCFL inverter operation, and high-voltage
+handling. The scaler board teaches display signal processing. This is one of the
+best learning teardowns in the bin — covers mains power, HV, analog video, and
+digital control on a few boards.
 
 > **WARNING:** The PSU board contains 100uF/450V and 160uF/450V capacitors that
-> can hold lethal charge even when unplugged. Before handling or recycling:
+> can hold lethal charge even when unplugged. Before handling:
 > 1. Verify no charge with a multimeter across cap terminals (should read <1V)
 > 2. If any voltage: discharge through a 10kΩ resistor (not a screwdriver — that
 >    can damage the cap and spark)
-> 3. Once confirmed discharged, safe to handle and recycle
+> 3. Once confirmed discharged, safe to handle and strip
 
-**Decision:** Discharge caps, then e-waste recycling bin. All boards and panel.
-Nothing salvageable.
+**Toss?** No — strip for HV caps, transformers, choke, fuse holder, and
+connectors. Excellent learning platform.
+
+**Decision:** **Discharge 450V caps first.** Then strip PSU board for components.
+Study scaler board for learning. Toss LCD panel and FPC ribbons.
+
+---
+
+## SPD-24: DStv Remote Control
+
+**Status:** Keep
+
+**Use for:**
+- IR protocol testing — pair with an IR receiver module on Arduino/ESP32 to
+  decode NEC/RC5 protocols
+- Spare remote if you still have a DStv sub
+- IR learning projects — clone codes to a universal remote or ESP32 IR blaster
+
+**Scrap for:**
+- N/A — more useful intact. IR LEDs and rubber keypad inside but not worth
+  stripping a working remote.
+
+**Learning value:** Moderate. Good intro to IR communication protocols. Point
+at an IR receiver, decode the signals, learn NEC encoding.
+
+**Decision:** Keep. Useful for IR protocol experiments and as a spare.
+
+---
+
+## SPD-25: HDMI Cable
+
+**Status:** Keep
+
+**Use for:**
+- Display connectivity for RPi, dev boards, decoders, any HDMI device
+- Ground station display connection
+- Always need at least one spare
+
+**Scrap for:** N/A — it's a cable. Use it.
+
+**Learning value:** None — it's a cable.
+
+**Decision:** Keep. Label length. Always useful.
+
+---
+
+## SPD-26: ARRIS DStv Decoder (F55525MC)
+
+**Status:** Strip — check for HDD first
+
+> ARRIS F55525MC, DStv Explora decoder, 12V/2.5A, HDMI, made in SA 2020.
+> Locked to MultiChoice — cannot be repurposed as a media player.
+
+**Use for:**
+- Nothing functional without a DStv subscription. Firmware is locked.
+
+**Scrap for:**
+- **2.5" SATA HDD (if present)** — Explora decoders typically have a 500GB-1TB
+  drive for PVR recording. This is the main prize — usable as external storage,
+  in a NAS, or as a Raspberry Pi data drive. Check first!
+- **Heatsinks** — SoC heatsinks, reusable
+- **HDMI connector** — can be desoldered for custom projects
+- **12V power jack** — standard barrel connector
+- **IR receiver module** — reusable for any IR remote project
+- **WiFi module (if present)** — some Exploras have WiFi
+
+**Learning value:** High. Modern ARM-based set-top box teardown. Learn to
+identify: ARM SoC, DDR memory, NAND/eMMC flash, HDMI transmitter IC, IR
+receiver circuit, tuner module, HDD interface. Good embedded Linux device
+to study.
+
+**Decision:** Open first — check for HDD (highest priority salvage). Then full
+teardown for learning. Keep HDD, heatsinks, IR receiver. Toss the locked
+main board after studying.
+
+---
+
+## SPD-27a: Fridge Compressor
+
+**Status:** Strip (low priority) — last in queue
+
+> QD brand sealed refrigeration compressor with Changlong/Seling start relay,
+> copper tubing. From a small fridge/bar fridge.
+
+**Use for:**
+- Scrap copper from the tubing (decent amount of clean copper)
+- Compressor motor could theoretically run as a vacuum pump or air compressor
+  (without refrigerant), but this is a niche project
+- Start relay — standard refrigeration part, reusable if you ever fix a fridge
+
+**Scrap for:**
+- **Copper tubing** — clean copper, reasonable scrap value in bulk
+- **Start relay (PTC/current type)** — reusable fridge repair part
+- **Motor windings** — scrap copper only if motor is cut open
+
+**Learning value:** Moderate. Learn how a hermetic compressor works (motor +
+compressor in sealed housing), refrigerant circuit basics (suction/discharge/
+process tubes), and PTC start relay operation. Good mechanical/thermal
+systems learning.
+
+**Decision:** Last in the strip queue — heavy and messy. Salvage the copper
+tubing and start relay. Leave the sealed compressor intact unless someone wants
+to cut it open for learning (the motor inside is interesting but not reusable).
+
+---
+
+## SPD-27b: Fridge Control Board
+
+**Status:** Strip — useful parts
+
+> PCB with DIP controller IC (LCD(005C)), 3x mains-rated relays, X2 safety
+> capacitor, piezo buzzer, ribbon cable to LCD display, electrolytic caps,
+> small transformer.
+
+**Use for:**
+- Nothing functional as a fridge controller. The DIP IC is application-specific.
+
+**Scrap for:**
+- **3x mains relays** — 240V rated, directly reusable for home automation,
+  irrigation, lighting control. Same function as the Fanhar relay (#9) but
+  you get three more. These are the priority salvage.
+- **Piezo buzzer** — second buzzer for the bin (matches #14)
+- **X2 safety capacitor** — mains-rated interference suppression cap, useful
+  for any mains PSU project
+- **Electrolytic caps** — standard values, spares
+- **Small transformer** — low-voltage step-down, could power small projects
+- **DIP IC socket** (if socketed) — reusable
+
+**Learning value:** Good. Learn relay coil/contact identification, mains safety
+capacitor types (X2 vs Y), and how a fridge control loop works (temperature
+sensor → IC → relay switching compressor/fan/defrost heater). The ribbon cable
+to LCD teaches flat-flex interfacing.
+
+**Decision:** Priority strip. Recover the three relays first (most useful),
+then buzzer, X2 cap, and transformer. The relays alone make this a valuable
+teardown — three free mains-rated relays.
+
+---
+
+## SPD-28: Orion 320 Landline Telephone
+
+**Status:** Strip (learning)
+
+> PSTN desktop telephone with speakerphone, speed-dial buttons, LCD display
+> area, DTMF keypad. Completely obsolete without a landline.
+
+**Use for:**
+- Nothing functional without PSTN service.
+
+**Scrap for:**
+- **Keypad matrix** — 4x3 or 4x4 matrix, can be wired to any microcontroller
+  for input. Interesting DIY input device.
+- **Speaker** — small speaker from handset/speakerphone, 8Ω, usable for audio
+  projects
+- **Electret microphone** — from handset, usable for audio sensing
+- **Handset curly cord (RJ-9)** — 4-conductor cable, reusable
+- **Hookswitch** — mechanical switch, reusable as a limit switch or contact
+- **Ringer/buzzer** — if present, another audio transducer
+
+**Learning value:** High for beginners. Teaches: keypad matrix scanning, DTMF
+tone generation, basic analog audio circuits (hybrid transformer, sidetone),
+and how a telephone line interface works. The keypad matrix is a classic
+microcontroller input exercise — connect rows and columns to GPIO, scan for
+button presses.
+
+**Decision:** Strip. The keypad matrix and microphone are the best parts. Good
+beginner electronics project to connect the keypad to an Arduino and read
+button presses. Keep the speaker for audio projects.
+
+---
+
+## SPD-29: SPI ATX-250GT Power Supply (250W)
+
+**Status:** Keep — high value bench tool
+
+> Sparkle Power International ATX-250GT, 250W ATX switching power supply.
+> AC input 115/230V. DC outputs: +3.3V/14A, +5V/25A, +12V (likely 15A+),
+> -12V/0.5A, +5Vsb/2A.
+
+**Use for:**
+- **Multi-voltage bench power supply** — provides 3.3V, 5V, 12V, and -12V
+  simultaneously from a single unit. High current capability. Just bridge
+  PS_ON (green wire) to ground to turn on without a motherboard.
+- Power supply for all routers (#17, #19, #20a need 12V)
+- High-current 5V source for RPi, ESP32, LED strips, servos
+- 12V source for motors, solenoids, relays, car accessories
+- 3.3V source for direct logic-level work without regulators
+- Combine +12V and -12V for ±12V analog circuits (op-amps)
+
+**Scrap for:**
+- N/A — far more valuable as a working PSU. Replacement cost R300-500.
+
+**Learning value:** If studied (don't strip): teaches complete ATX PSU design —
+PFC stage, main switching topology, multiple output regulation, standby supply,
+protection circuits (OVP, OCP, SCP), and power sequencing.
+
+**Rooivalk relevance:** Direct. This becomes the primary bench supply for
+testing all electronics: flight controllers, ESCs, GPS modules, FPV cameras,
+companion computers. The multi-voltage output eliminates the need for separate
+5V, 12V, and 3.3V supplies.
+
+**Decision:** **Keep intact — test first.** Bridge green wire (PS_ON) to any
+black wire (ground) with a paperclip or switch. If the fan spins and voltages
+are correct on the ATX connector, it's good. Consider building a breakout
+board with binding posts for easy bench access to each voltage rail. This is
+the second most valuable item in the bin after the hoverboard motors.
 
 ---
 
@@ -667,29 +909,36 @@ Nothing salvageable.
 
 | # | Component | Decision | Action Required |
 |---|-----------|----------|-----------------|
-| 01 | Cudy WR3000 | Keep intact | Flash OpenWrt when ready |
-| 02 | MT7615DN Router | Keep (low priority) | Salvage antenna if space needed |
-| 03 | PS4 DualShock 4 | Keep intact | None — ready to use |
-| 04a | Hoverboard Board (intact) | Keep intact | Flash FOC firmware when building rover |
-| 04b | Hoverboard Board (harvest) | Strip for parts | Desolder MOSFETs, shunts, caps, connectors |
-| 04c | Hub Motors x2 | Keep | Store upright |
+| 01 | Cudy WR3000 | **Keep intact** | Flash OpenWrt when ready |
+| 02 | MT7615DN Router | Keep | Backup; salvage antenna if space needed |
+| 03 | PS4 DualShock 4 | **Keep intact** | Ready to use |
+| 04a | Hoverboard Board (intact) | **Keep intact** | Flash FOC firmware for rover build |
+| 04b | Hoverboard Board (harvest) | **Strip (priority 1)** | MOSFETs, shunts, caps, connectors |
+| 04c | Hub Motors x2 | **Keep** | Store upright |
 | 05 | USB Charger PCB | Keep | Mount in enclosure for safety |
 | 06 | Boost Converter | Keep | Label current rating |
 | 07 | WR3E WiFi Module | Keep | Flash LibreTiny when needed |
-| 08 | 56K Modem | **Toss** | E-waste bin |
-| 09 | Relay Module | Keep | Use for home automation |
+| 08 | 56K Modem | Strip (learning) | Practice + SMD identification |
+| 09 | Relay Module | Keep | Home automation |
 | 10 | Button Breakout | Keep | Small parts drawer |
-| 11 | Parrot Minikit+ | Keep intact | Anti-static bag, test acoustic detection |
+| 11 | Parrot Minikit+ | **Keep intact** | Acoustic detection, BT serial bridge |
 | 12 | BT Audio Receiver | Keep | Anti-static bag |
-| 13 | LED Driver | **Toss** | E-waste bin |
+| 13 | LED Driver | **Toss** | Only true toss — too small/unmarked |
 | 14 | Piezo Buzzer | Keep | Desolder from RC board, toss board |
-| 15 | Washing Machine Button Panel | **Toss** | E-waste bin — proprietary form factor |
-| 16 | LG TV T-Con Board | **Toss** | E-waste bin — zero salvage value |
-| 17 | ZyXEL CB71 Gateway | Keep (test first) | Test with 12V PSU, use as switch/AP |
-| 18 | D-Link DSL-2640U | **Toss** | E-waste bin — ADSL obsolete |
-| 19 | Huawei B315s-936 (4G LTE) | **Keep** | Get data SIM, use as field link |
-| 20a | Vodafone H 500-s (keep) | Keep (low priority) | Backup router |
-| 20b | Vodafone H 500-s (dupe) | **Toss** | E-waste bin — redundant |
-| 21 | Wall-Wart Adapters (~6) | Keep (tested ones) | Test, label voltage/current, toss dead |
+| 15 | Washing Machine Panel | Strip (learning) | Beginner desoldering practice |
+| 16 | LG TV T-Con Board | Strip (learning) | QFP hot-air desoldering practice |
+| 17 | ZyXEL CB71 Gateway | Keep (test first) | Test with 12V PSU, use as switch |
+| 18 | D-Link DSL-2640U | Strip (learning) | UART console hunting, RJ-45 jacks |
+| 19 | Huawei B315s-936 (4G) | **Keep intact** | Get data SIM, field link |
+| 20a | Vodafone H 500-s | Keep | Backup router |
+| 20b | Vodafone H 500-s (dupe) | Strip (learning) | Antennas, heatsinks, SPI flash reading |
+| 21 | Wall-Wart Adapters (~6) | Keep (tested) | Test, label voltage/current, toss dead |
 | 22 | NiMH Quick Charger | Keep | Test with cells |
-| 23 | BenQ Monitor (disassembled) | **Toss** | **Discharge 450V caps first**, then e-waste |
+| 23 | BenQ Monitor | **Strip (parts + learning)** | **Discharge 450V caps first!** HV caps, transformers, choke |
+| 24 | DStv Remote | Keep | IR protocol experiments |
+| 25 | HDMI Cable | Keep | Always useful |
+| 26 | ARRIS DStv Decoder | **Strip (check HDD first!)** | HDD is main prize, then full teardown |
+| 27a | Fridge Compressor | Strip (last — heavy) | Copper tubing, start relay |
+| 27b | Fridge Control Board | **Strip (priority 2)** | 3x mains relays, buzzer, X2 cap |
+| 28 | Orion 320 Telephone | Strip (learning) | Keypad matrix, speaker, mic |
+| 29 | ATX-250GT PSU (250W) | **Keep — test first** | Bridge PS_ON to GND, verify voltages |

--- a/apps/docs/docs/research/spare-parts-decisions.md
+++ b/apps/docs/docs/research/spare-parts-decisions.md
@@ -387,6 +387,73 @@ removing its buzzer since it may be damaged.
 
 ---
 
+## SPD-15: Panasonic Washing Machine Button Panel PCB
+
+**Status:** Toss
+
+> Part number A4274008084. Brown phenolic PCB with three rocker/push switches,
+> ribbon cable, R13x resistors, CN connectors. From a Panasonic washing machine
+> control panel.
+
+**Use for:**
+- Nothing practical. The switches are a proprietary form factor moulded to fit
+  a specific washing machine fascia. They won't mount in any standard enclosure
+  or breadboard setup.
+
+**Scrap for:**
+- The rocker switches — but they're non-standard shape/mounting, designed for a
+  specific plastic housing that you don't have. Standard panel-mount rockers are
+  R5 each.
+- SMD resistors (R13x series) — generic, not worth desoldering from phenolic
+  board.
+- Ribbon cable — proprietary pitch and length. Useless without the matching
+  connector on the main washer board.
+
+**Toss?** **Yes.** Proprietary form factor throughout. Even the switches can't
+be reused without their matching housing. No components worth the desoldering
+effort.
+
+**Decision:** E-waste recycling bin. Don't strip anything.
+
+---
+
+## SPD-16: LG TV T-Con (Timing Controller) Board
+
+**Status:** Toss
+
+> Board number EAX36987601. Green PCB with two large Panasonic MN-series QFP
+> ICs (MN1 804 RT1, made in Japan), FPC connector, LVDS edge connectors,
+> serial data/clock lines (SDAT, SCLK), small electrolytics. Converts main
+> board LVDS signal into LCD panel row/column driver signals.
+
+**Use for:**
+- Nothing. A T-Con board is entirely application-specific — it converts a
+  particular LVDS timing format into signals for a matched LCD panel. Without
+  the exact panel and main board, it does nothing. Cannot be reprogrammed or
+  repurposed.
+
+**Scrap for:**
+- **Panasonic MN-series ICs** — proprietary display timing controllers with no
+  public datasheet. Cannot be reflashed or reused for any other purpose.
+  Desoldering QFP-128+ packages without hot air is destructive, and even with
+  hot air, the chips are worthless.
+- **FPC connector** — panel-specific pin count and pitch. New FPC connectors of
+  any standard size are R3.
+- **Small electrolytic caps (x2)** — likely 10-47uF, low voltage. Worth less
+  than the solder to remove them.
+- **Edge connectors** — moulded for a specific LVDS ribbon. Not a standard
+  pinout.
+- **SMD passives** — dozens of tiny resistors and caps, all generic and not
+  worth harvesting.
+
+**Toss?** **Yes.** Every component on this board is either proprietary
+(the ICs, connectors) or too cheap to justify desoldering (passives, caps).
+The board itself is lead-free and RoHS — safe for e-waste recycling.
+
+**Decision:** E-waste recycling bin. Zero salvage value.
+
+---
+
 ## Summary of Decisions
 
 | # | Component | Decision | Action Required |
@@ -407,3 +474,5 @@ removing its buzzer since it may be damaged.
 | 12 | BT Audio Receiver | Keep | Anti-static bag |
 | 13 | LED Driver | **Toss** | E-waste bin |
 | 14 | Piezo Buzzer | Keep | Desolder from RC board, toss board |
+| 15 | Washing Machine Button Panel | **Toss** | E-waste bin — proprietary form factor |
+| 16 | LG TV T-Con Board | **Toss** | E-waste bin — zero salvage value |

--- a/apps/docs/docs/research/spare-parts-decisions.md
+++ b/apps/docs/docs/research/spare-parts-decisions.md
@@ -1,0 +1,409 @@
+# Spare Parts — Component Decisions
+
+Mechanical/electronic decision records for each salvaged component. Documents
+the reasoning behind keep, harvest, repurpose, or toss decisions.
+
+**Cross-reference:** [Spare Parts Bin Inventory](./spare-parts-bin.md)
+
+---
+
+## Decision Format
+
+Each entry follows this structure:
+
+- **Use for:** Primary intended use case(s)
+- **Scrap for:** Components worth harvesting if the unit itself isn't kept whole
+- **Toss?:** Yes/no and why
+- **Decision:** Final verdict with reasoning
+
+---
+
+## SPD-01: Cudy WR3000 WiFi 6 Router
+
+**Status:** Keep — use as-is
+
+**Use for:**
+- Flash OpenWrt and deploy as dedicated ground station router for drone ops
+- WiFi 6 (802.11ax) gives better range and throughput for FPV relay or MAVLink
+  telemetry forwarding
+- Portable VPN gateway for field work
+- Mesh node for extended coverage at test sites
+
+**Scrap for:**
+- N/A — far more valuable intact and working
+
+**Toss?** No. This is a current-generation WiFi 6 router with excellent OpenWrt
+support. Retail value ~R800+.
+
+**Decision:** Keep intact. Flash OpenWrt when needed for ground station role.
+Can serve double duty as a home lab router in the meantime.
+
+---
+
+## SPD-02: Older MT7615DN WiFi Router
+
+**Status:** Keep — limited use
+
+**Use for:**
+- Backup router if the Cudy dies
+- OpenWrt experimentation/learning without risking the better router
+- 2.4GHz antenna donor (SMA/RP-SMA connector)
+
+**Scrap for:**
+- External 2.4GHz antenna(s) — useful for RF projects, worth keeping
+- Heatsinks (if any) — marginal value
+
+**Toss?** No, but only because the antenna is useful and it costs nothing to
+store. If space becomes an issue, salvage the antenna and toss the rest.
+
+**Decision:** Keep on shelf as backup. Low priority.
+
+---
+
+## SPD-03: PS4 DualShock 4 (JDM-011)
+
+**Status:** Keep — multi-project use
+
+**Use for:**
+- Manual override controller for drone via Bluetooth HID → RPi companion
+  computer. Dual analog sticks map to throttle/yaw + pitch/roll naturally.
+- Ground rover controller (paired with hoverboard motors, SPD-04)
+- General robotics input device
+- Gaming (its original purpose)
+
+**Scrap for:**
+- N/A — worth far more as a working controller
+- If it ever dies: analog stick modules (Alps RKJXV), IMU (accelerometer +
+  gyro), Bluetooth module, touchpad, vibration motors
+
+**Toss?** Absolutely not. A working DualShock 4 is R600-900 retail.
+
+**Decision:** Keep intact. Use as primary manual control input for any
+RC/robotics project. Well-supported in Linux/Python (ds4drv, pygame, evdev).
+
+---
+
+## SPD-04a: Hoverboard Controller Board (Intact Unit)
+
+**Status:** Keep — do not strip
+
+**Use for:**
+- Dual brushless DC motor controller for ground rover / robot platform
+- Reflash with open-source FOC firmware
+  (EFeru/hoverboard-firmware-hack-FOC) for proper torque control, UART/I2C
+  command interface, and speed feedback
+- Drives both hub motors (SPD-04c) from a single board
+- Built-in current sensing, hall sensor decoding, and 36V power path
+- Electric go-kart, CNC table drive, conveyor system
+
+**Scrap for:**
+- N/A — designated "keep intact" unit. Use SPD-04b for harvesting.
+
+**Toss?** No. A working hoverboard controller with open-source firmware support
+is worth R300-500. Combined with the hub motors it's a complete drive system.
+
+**Decision:** Keep intact. Do NOT desolder anything. This board + two hub motors
+= a complete ground vehicle drivetrain. Flash FOC firmware when ready to build
+the rover.
+
+---
+
+## SPD-04b: Hoverboard Controller Board (Harvest Unit)
+
+**Status:** Keep — designated parts donor
+
+**Use for:**
+- Component harvesting only (see "Scrap for" below)
+- Practice desoldering SMD power components if you're building that skill
+
+**Scrap for:**
+- **Power MOSFETs (6-8x):** CLN89 or similar, D-PAK package, 60-100V 30A+.
+  Easy to desolder with wide chisel tip or hot air. These are R15-30 each
+  retail. Useful for custom H-bridges, motor drivers, DC-DC converters, e-bike
+  controllers, high-side/low-side switching.
+- **Current sense resistors (4x):** R004 (4mΩ) and R010 (10mΩ) precision
+  shunts. Annoying to source individually. Essential for any motor current
+  monitoring or battery coulomb counting.
+- **Electrolytic caps (2-4x):** 220uF 35-50V. Standard power rail filtering.
+  Always useful to have spares.
+- **JST-XH connectors (6+):** 2.54mm pitch, through-hole. Easy to desolder,
+  directly reusable in any project wiring.
+- **STM32/GD32 MCU:** Only if you have hot air and want the QFP-48 chip.
+  GD32F130 is a capable ARM Cortex-M3. Low priority — dev boards are cheap.
+
+**Toss?** The bare PCB after harvesting, yes. The components themselves, no.
+
+**Decision:** Harvest in this order of priority: MOSFETs first (highest value),
+then current sense resistors, then connectors, then caps. Toss the stripped
+board.
+
+---
+
+## SPD-04c: Hoverboard Hub Motors (x2)
+
+**Status:** Keep — high value
+
+**Use for:**
+- Ground rover / autonomous patrol platform (with SPD-04a controller)
+- Electric skateboard or go-kart build
+- Belt grinder or bench lathe spindle drive (high torque at low RPM)
+- Conveyor or turntable drive
+- Counter-UAS ground station on wheels
+
+**Scrap for:**
+- Neodymium magnets (if motor ever dies) — strong ring magnets, useful for
+  magnetic mounts, sensors, generators
+- Copper windings — scrap copper value only, not worth it unless motor is dead
+
+**Toss?** No. Most valuable items in the entire spare parts bin. ~R500-700 each
+retail for replacement hub motors.
+
+**Decision:** Keep both. Store upright to avoid flat-spotting tyres. Pair with
+SPD-04a controller board for a complete drive system.
+
+---
+
+## SPD-05: USB Wall Charger PCB
+
+**Status:** Keep — bench tool
+
+**Use for:**
+- Bench 5V supply for ESP32, Arduino, RPi Zero, any USB-powered dev board
+- Quick phone/device charging at the workbench
+
+**Scrap for:**
+- N/A — more useful intact. Components (switching transistor, transformer,
+  diodes) are application-specific and not worth harvesting.
+
+**Toss?** No, but **safety note:** this is a bare PCB that handles mains AC.
+Mount it in an enclosure or at minimum wrap exposed mains traces with kapton
+tape before use.
+
+**Decision:** Keep. Mount safely. Use as bench supply.
+
+---
+
+## SPD-06: 1S-to-5V USB Boost Converter
+
+**Status:** Keep — field power tool
+
+**Use for:**
+- Power a RPi Zero 2W from a single LiPo cell for field testing the AI
+  companion computer tier
+- Portable USB power from any 3.7V LiPo — cameras, sensors, LED strips
+- Emergency phone charging from a salvaged laptop cell
+
+**Scrap for:**
+- N/A — it's a R15 module, not worth stripping
+
+**Toss?** No. Tiny, useful, costs nothing to store.
+
+**Decision:** Keep in parts bin. Label the max current rating if known (~1A
+typical for these modules).
+
+---
+
+## SPD-07: Tuya WR3E WiFi Module (RTL8710BN)
+
+**Status:** Keep — IoT building block
+
+**Use for:**
+- Reflash with LibreTiny or OpenBeken firmware to break free of Tuya cloud
+- UART-to-WiFi bridge for drone telemetry (lightweight alternative to ESP32)
+- IoT sensor node: temperature, humidity, door/window sensor
+- Smart home relay control, LED dimmer
+- WiFi-based presence detection
+
+**Scrap for:**
+- N/A — it IS the component. Nothing to harvest from a module this small.
+
+**Toss?** No. Equivalent to a R30-50 ESP-01 but with better firmware options
+via LibreTiny.
+
+**Decision:** Keep in anti-static bag. Flash LibreTiny when you have a specific
+use case. Most likely deployment: smart home sensor or telemetry bridge.
+
+---
+
+## SPD-08: Laptop 56K Modem Card
+
+**Status:** Toss
+
+**Use for:**
+- Nothing. Dial-up is extinct. No PSTN line to connect to. No software supports
+  it. Cannot be repurposed as a different interface.
+
+**Scrap for:**
+- Nothing worth the effort. The RJ-11 jack is obsolete. The DAA (data access
+  arrangement) IC is application-specific. No useful passives.
+
+**Toss?** **Yes.** Zero use cases across any project category.
+
+**Decision:** E-waste recycling bin.
+
+---
+
+## SPD-09: Fanhar Relay Module
+
+**Status:** Keep — home automation
+
+**Use for:**
+- Home automation: switching irrigation pumps, grow lights, fans, heaters
+- Garage door opener interface
+- Any project needing microcontroller-controlled mains or high-current DC
+  switching
+- Opto-isolated input is safe to drive from 3.3V logic (ESP32, RPi GPIO)
+
+**Scrap for:**
+- N/A — it's a R20 module and more useful intact
+
+**Toss?** No. Not useful for drone projects (too heavy, wrong use case) but
+very useful for home/garden automation.
+
+**Decision:** Keep in parts bin. First likely use: irrigation or lighting
+control.
+
+---
+
+## SPD-10: Tactile Push Button Breakout
+
+**Status:** Keep — parts bin filler
+
+**Use for:**
+- Breadboard prototyping: reset buttons, mode selectors, boot pin triggers
+- Quick input for any microcontroller project
+
+**Scrap for:**
+- The tactile switch itself if the breakout PCB is too big for your application
+  (just snip it off)
+
+**Toss?** No, but only because it's tiny and costs nothing to store. Zero
+monetary value.
+
+**Decision:** Keep in small parts drawer. Will get used eventually on some
+breadboard project.
+
+---
+
+## SPD-11: Parrot Minikit+ Complete Unit (MPP_MB_07)
+
+**Status:** Keep intact — more valuable as a unit than as parts
+
+> **Note:** This was associated with a Parrot drone that has been stolen. The
+> Minikit+ itself (Bluetooth car kit) is still here and fully functional.
+
+**Use for:**
+- **Bluetooth serial bridge (SPP):** CSR BlueCore5 supports Serial Port
+  Profile. Use as a wireless UART bridge for microcontroller projects — pair
+  with phone or laptop, stream serial data over BT 2.1 at ~10m range.
+- **Acoustic drone detection sensor:** The MEMS microphone + amplifier chain is
+  already filtered for voice frequencies. Propeller noise signatures
+  (100-8000Hz) fall within this range. Feed audio to a RPi for real-time FFT
+  analysis of drone acoustic signatures.
+- **Hands-free intercom:** Use as-is for workshop/garage comms paired with a
+  phone.
+- **BT audio sink:** Stream music/audio from phone to any amp via speaker
+  output pads.
+- **Enclosure design reference:** The button membrane with integrated light
+  pipes and visor clip mechanism are excellent physical design references for
+  3D-printed housings.
+
+**Scrap for (only if it dies):**
+- MEMS microphone — useful standalone for any audio sensing project
+- Class D speaker amplifier IC — can drive small speakers from line-level input
+- CSR BlueCore5 module — Bluetooth radio, but hard to reuse without the full
+  circuit
+- Status LEDs — generic, not worth the effort
+- Light pipe / button membrane — design reference, keep regardless
+
+**Toss?** No. Fully functional Bluetooth device with multiple reuse paths. The
+acoustic detection angle makes it directly relevant to Rooivalk.
+
+**Decision:** Keep as a complete unit. Do not disassemble. Store in anti-static
+bag. Most promising use: acoustic drone detection sensor feeding audio to the
+detector app's ML pipeline.
+
+---
+
+## SPD-12: Bluetooth Audio Receiver Module
+
+**Status:** Keep
+
+**Use for:**
+- Portable Bluetooth speaker build: pair with a salvaged speaker driver + amp
+  + power bank
+- Workshop audio: stream music from phone to bench speakers
+- Audio input for any amplifier that only has wired inputs
+
+**Scrap for:**
+- N/A — it's already a minimal module
+
+**Toss?** No. Small, useful, and BT audio receivers are handy to have around.
+
+**Decision:** Keep in anti-static bag. Use when building a Bluetooth speaker or
+adding wireless audio to existing speakers.
+
+---
+
+## SPD-13: LED Driver / Voltage Doubler Tiny PCB
+
+**Status:** Toss
+
+**Use for:**
+- Driving white LEDs from low voltage (charge pump doubles input voltage).
+  Extremely niche application.
+
+**Scrap for:**
+- Nothing. The charge pump IC is unmarked and the passives are too small to be
+  worth desoldering.
+
+**Toss?** **Yes.** A new charge pump module is R5 if you ever need one, and
+you'd know the specs.
+
+**Decision:** E-waste recycling bin.
+
+---
+
+## SPD-14: Piezo Buzzer (from RC Toy Board)
+
+**Status:** Keep — desolder and bin
+
+**Use for:**
+- Lost-model alarm on any drone build
+- Status beeper (boot confirmation, low battery warning, error codes)
+- Audible alert on any microcontroller project
+- Morse code practice oscillator
+
+**Scrap for:**
+- N/A — the buzzer IS the salvaged part. The rest of the RC toy board is
+  e-waste after removing this.
+
+**Toss?** No. Piezo buzzers are useful and this one is free.
+
+**Decision:** Desolder from the good RC toy board (two wires, 5 seconds).
+Label the frequency if you can measure it. Toss the stripped RC board. The
+second RC board (burnt IC + blown cap) goes straight to e-waste — don't bother
+removing its buzzer since it may be damaged.
+
+---
+
+## Summary of Decisions
+
+| # | Component | Decision | Action Required |
+|---|-----------|----------|-----------------|
+| 01 | Cudy WR3000 | Keep intact | Flash OpenWrt when ready |
+| 02 | MT7615DN Router | Keep (low priority) | Salvage antenna if space needed |
+| 03 | PS4 DualShock 4 | Keep intact | None — ready to use |
+| 04a | Hoverboard Board (intact) | Keep intact | Flash FOC firmware when building rover |
+| 04b | Hoverboard Board (harvest) | Strip for parts | Desolder MOSFETs, shunts, caps, connectors |
+| 04c | Hub Motors x2 | Keep | Store upright |
+| 05 | USB Charger PCB | Keep | Mount in enclosure for safety |
+| 06 | Boost Converter | Keep | Label current rating |
+| 07 | WR3E WiFi Module | Keep | Flash LibreTiny when needed |
+| 08 | 56K Modem | **Toss** | E-waste bin |
+| 09 | Relay Module | Keep | Use for home automation |
+| 10 | Button Breakout | Keep | Small parts drawer |
+| 11 | Parrot Minikit+ | Keep intact | Anti-static bag, test acoustic detection |
+| 12 | BT Audio Receiver | Keep | Anti-static bag |
+| 13 | LED Driver | **Toss** | E-waste bin |
+| 14 | Piezo Buzzer | Keep | Desolder from RC board, toss board |


### PR DESCRIPTION
Catalogue of all salvaged components identified from workshop photos, with descriptions, usefulness assessment, and applicability across all projects (drone, IoT, networking, audio, general prototyping).

https://claude.ai/code/session_01PXe3eWFVeR45h82saifZ2b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive spare-parts inventory cataloging salvaged workshop components with quantities, condition, functional notes, cross-project applicability groups, per-item guidance (notably multiple hoverboard-derived items, networking and control parts) and practical storage recommendations including assembled keep, anti-static bagging, labeled bins, shelving/racking, and e-waste handling with HV capacitor discharge safety.
  * Added a companion decision document with 23 structured component records (keep/harvest/toss guidance), handling priorities, testing and labeling steps, and a summary mapping each item to its final action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->