### PR TITLE
docs: add Baton task coordination guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -345,3 +345,7 @@ directory:
 - `apps/detector/CLAUDE.md` — Python config system, hardware platforms, linting
 - `apps/threat-simulator-desktop/CLAUDE.md` — WASM/native compilation, Trunk,
   Tauri
+
+## Baton Integration
+
+Baton is the shared task graph for cross-repo work. When the `baton` MCP server is available, agents should check for existing work with `task_check` at the start of meaningful tasks, create or claim visible work with `task_notify`/`log_agent_message`, update the task when significant new information becomes available, and log completion or blockers before handing off.


### PR DESCRIPTION
Adds concise Baton MCP coordination guidance to CLAUDE.md: check task_check at meaningful task start, create or claim visible work with task_notify/log_agent_message, update tasks as significant information arrives, and log completion or blockers before handoff.