### PR TITLE
fix(marketing): dead space above first sections, contact styling, dates +2 quarters

### DIFF
--- a/apps/marketing/src/app/compliance/iso-27001/page.tsx
+++ b/apps/marketing/src/app/compliance/iso-27001/page.tsx
@@ -74,7 +74,7 @@ export default function ISO27001Page(): React.ReactElement {
                 </div>
                 <div className={styles.statusItem}>
                   <span className={styles.statusLabel}>Target Date</span>
-                  <span className={styles.statusBadgePlanned}>Q4 2026</span>
+                  <span className={styles.statusBadgePlanned}>Q2 2027</span>
                 </div>
                 <div className={styles.statusItem}>
                   <span className={styles.statusLabel}>Implementation</span>
@@ -82,7 +82,7 @@ export default function ISO27001Page(): React.ReactElement {
                 </div>
                 <div className={styles.statusItem}>
                   <span className={styles.statusLabel}>Next Milestone</span>
-                  <span className={styles.statusBadgePlanned}>Q3 2026</span>
+                  <span className={styles.statusBadgePlanned}>Q1 2027</span>
                 </div>
               </div>
             </div>

--- a/apps/marketing/src/app/contact/contact.module.css
+++ b/apps/marketing/src/app/contact/contact.module.css
@@ -121,6 +121,17 @@
   grid-column: 1 / -1;
 }
 
+/* Get in Touch spans the full row, so spread its three contact channels
+   into columns on desktop instead of stacking them beside dead space. */
+@media (min-width: 768px) {
+  .grid > .card:first-child .contentGroup {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 2rem;
+    align-items: start;
+  }
+}
+
 .card {
   border-radius: 1rem;
   border: 1px solid rgba(var(--primary), 0.25);
@@ -187,16 +198,20 @@
   display: inline-block;
   margin-top: 0.75rem;
   border-radius: 0.375rem;
-  background: linear-gradient(
-    to bottom right,
-    rgb(var(--primary)),
-    rgb(var(--secondary))
-  );
+  /* Solid amber like the site-wide primary Button — the old amber→slate
+     gradient left near-black text on a dark surface (unreadable). */
+  background: rgb(var(--primary));
   padding: 0.5rem 1rem;
   font-weight: 700;
-  color: rgb(var(--dark));
+  color: rgb(var(--tactical-black));
   box-shadow: 0 0 20px rgba(var(--primary), 0.3);
-  transition: transform 0.2s;
+  transition:
+    transform 0.2s,
+    background-color 0.2s;
+}
+
+.primaryButton:hover {
+  background: rgba(var(--primary), 0.9);
 }
 
 .primaryButton:hover {

--- a/apps/marketing/src/app/globals.css
+++ b/apps/marketing/src/app/globals.css
@@ -637,9 +637,10 @@ section {
   padding: clamp(3.5rem, 8vw, 6.5rem) 0;
 }
 
-section:first-of-type {
-  padding-top: clamp(5.5rem, 12vw, 8.5rem);
-}
+/* No first-of-type top-padding bump: the nav is sticky (in-flow), so first
+   sections need no extra clearance — and the (0,1,1) specificity of
+   section:first-of-type silently beat CSS-module section classes like the
+   hero's, adding ~136px of dead space above every page's first section. */
 
 .section-tight {
   padding: clamp(2rem, 5vw, 4rem) 0;

--- a/apps/marketing/src/app/home.tsx
+++ b/apps/marketing/src/app/home.tsx
@@ -84,7 +84,7 @@ export default function HomePage(): React.ReactElement {
                 name: "When can I get one?",
                 acceptedAnswer: {
                   "@type": "Answer",
-                  text: "Preorders open now with no deposit required. First deliveries Q3 2026.",
+                  text: "Preorders open now with no deposit required. First deliveries Q1 2027.",
                 },
               },
               {

--- a/apps/marketing/src/app/preorder/PreorderPageClient.tsx
+++ b/apps/marketing/src/app/preorder/PreorderPageClient.tsx
@@ -657,8 +657,8 @@ export default function PreorderPage(): React.ReactElement {
               <h3 className={styles.faqQuestion}>When will I receive it?</h3>
               <p className={styles.faqAnswer}>
                 Each product card shows its delivery phase. Kestrel Mesh first
-                deliveries are planned for Q3 2026. Sentinel Ring enterprise
-                deployments begin Q4 2026. We&apos;ll email you as your date
+                deliveries are planned for Q1 2027. Sentinel Ring enterprise
+                deployments begin Q2 2027. We&apos;ll email you as your date
                 approaches.
               </p>
             </div>

--- a/apps/marketing/src/app/sbir/SBIRPageClient.tsx
+++ b/apps/marketing/src/app/sbir/SBIRPageClient.tsx
@@ -149,7 +149,7 @@ export default function SBIRPage(): React.ReactElement {
                         <span
                           className={`${styles.detailValue} ${styles.detailValueWarning}`}
                         >
-                          Q4 2026
+                          Q2 2027
                         </span>
                       </div>
                       <div className={styles.detailRow}>
@@ -159,7 +159,7 @@ export default function SBIRPage(): React.ReactElement {
                         <span
                           className={`${styles.detailValue} ${styles.detailValueWarning}`}
                         >
-                          Q2 2026
+                          Q4 2026
                         </span>
                       </div>
                       <div className={styles.detailRow}>
@@ -179,7 +179,7 @@ export default function SBIRPage(): React.ReactElement {
                         <span
                           className={`${styles.detailValue} ${styles.detailValueWarning}`}
                         >
-                          Q1 2027
+                          Q3 2027
                         </span>
                       </div>
                     </div>

--- a/apps/marketing/src/app/unit-economics/UnitEconomicsPageClient.tsx
+++ b/apps/marketing/src/app/unit-economics/UnitEconomicsPageClient.tsx
@@ -142,7 +142,7 @@ const funding = {
   seriesA: {
     stage: "Series A",
     amount: "R120M (~$6.7M)",
-    timeline: "Q3 2026",
+    timeline: "Q1 2027",
     milestones: ["Proven revenue", "5 operational installations"],
   },
   exit: {

--- a/apps/marketing/src/components/AnnouncementBar.tsx
+++ b/apps/marketing/src/components/AnnouncementBar.tsx
@@ -29,7 +29,7 @@ export const AnnouncementBar: React.FC = () => {
     <div className={styles.bar} role="banner">
       <span className={styles.dot} aria-hidden="true" />
       <span className={styles.message}>
-        Early access open &middot; Kestrel Mesh ships Q3 2026
+        Early access open &middot; Kestrel Mesh ships Q1 2027
       </span>
       <a href="/preorder" className={styles.cta}>
         Preorder <span aria-hidden="true">→</span>

--- a/apps/marketing/src/components/sections/ContactSection.tsx
+++ b/apps/marketing/src/components/sections/ContactSection.tsx
@@ -21,7 +21,7 @@ export const ContactSection: React.FC = () => {
             <h3 className={styles.cardTitle}>Preorder & Sales</h3>
             <p className={styles.cardDescription}>
               Training facilities, event organizers, and security teams —
-              preorder your system today. No deposit, delivery Q3 2026.
+              preorder your system today. No deposit, delivery Q1 2027.
             </p>
             <div className={styles.buttonGroup}>
               <Button

--- a/apps/marketing/src/components/sections/HeroSection.tsx
+++ b/apps/marketing/src/components/sections/HeroSection.tsx
@@ -11,7 +11,7 @@ export const HeroSection: React.FC = () => {
         {/* Status indicator with live dot */}
         <p className={styles.statusLine}>
           <span className={styles.statusDot} aria-hidden="true" />
-          Early access open · Kestrel Mesh ships Q3 2026
+          Early access open · Kestrel Mesh ships Q1 2027
         </p>
 
         {/* Clear headline - what you get */}

--- a/apps/marketing/src/components/sections/TimelineSection.tsx
+++ b/apps/marketing/src/components/sections/TimelineSection.tsx
@@ -14,7 +14,7 @@ export const TimelineSection: React.FC = () => {
       description:
         "Complete mechanical prototype, achieve certification, launch Kestrel Mesh D2C",
       milestones: [
-        "Complete mechanical prototype (May 2026)",
+        "Complete mechanical prototype (Nov 2026)",
         "Achieve CPSC certification",
         "Launch Kestrel Mesh D2C, target 4,500+ units",
         "Integrate initial AI detection into Sentinel Ring prototype",
@@ -29,8 +29,8 @@ export const TimelineSection: React.FC = () => {
       description:
         "FAA waiver approved, first Sentinel Ring pilot, AI detection deployment",
       milestones: [
-        "FAA waiver approved (June 2026)",
-        "First Sentinel Ring pilot live (Q2 2027)",
+        "FAA waiver approved (Dec 2026)",
+        "First Sentinel Ring pilot live (Q4 2027)",
         "Deploy AI-based detection and tracking",
         "Kestrel Mesh expands to 15,000 units",
         "FY27 Revenue Target: $5M / R83M",
@@ -92,7 +92,7 @@ export const TimelineSection: React.FC = () => {
 
       if (dateMatch) {
         const dateStr = dateMatch[1];
-        // Parse dates like "May 2026", "June 2026", "Q2 2027"
+        // Parse dates like "Nov 2026", "Dec 2026", "Q4 2027"
         if (dateStr.includes("Q1")) {
           eventDate = new Date(dateStr.replace("Q1", "March"));
         } else if (dateStr.includes("Q2")) {
@@ -193,7 +193,7 @@ export const TimelineSection: React.FC = () => {
           <RevealSection>
             <div className={styles.timelineCta}>
               <p className={styles.timelineCtaText}>
-                First deliveries Q3 2026. Reserve your place in the queue —
+                First deliveries Q1 2027. Reserve your place in the queue —
                 no deposit required.
               </p>
               <div className={styles.timelineCtaButtons}>

--- a/apps/marketing/src/data/products.ts
+++ b/apps/marketing/src/data/products.ts
@@ -92,7 +92,7 @@ export const phases: Record<ProductPhase, ProductPhaseInfo> = {
     id: "seed",
     name: "Seed: Consumer Launch",
     shortName: "Seed",
-    timeline: "Q1 2026 - Q3 2026 • Delivery Jul-Oct 2026",
+    timeline: "Q3 2026 - Q1 2027 • Delivery Jan-Apr 2027",
     funding: "$1.5M",
     color: "#22c55e", // green
     description:
@@ -102,7 +102,7 @@ export const phases: Record<ProductPhase, ProductPhaseInfo> = {
     id: "series-a",
     name: "Series A: Sentinel Ring & DoD",
     shortName: "Series A",
-    timeline: "Q4 2026 - Q3 2027 • Delivery Apr-Aug 2027",
+    timeline: "Q2 2027 - Q1 2028 • Delivery Oct 2027-Feb 2028",
     funding: "$8-12M",
     color: "#3b82f6", // blue
     description: "Enterprise platform launch and DoD validation",
@@ -111,7 +111,7 @@ export const phases: Record<ProductPhase, ProductPhaseInfo> = {
     id: "series-b",
     name: "Series B: Ground Systems",
     shortName: "Series B",
-    timeline: "Q1-Q2 2028 • Delivery Aug 2028",
+    timeline: "Q3-Q4 2028 • Delivery Feb 2029",
     funding: "$15-20M",
     color: "#8b5cf6", // purple
     description: "Ground control systems and production scaling",
@@ -120,7 +120,7 @@ export const phases: Record<ProductPhase, ProductPhaseInfo> = {
     id: "series-c",
     name: "Series C: Aerial Platform",
     shortName: "Series C",
-    timeline: "Q1-Q2 2029 • Delivery Aug 2029",
+    timeline: "Q3-Q4 2029 • Delivery Feb 2030",
     funding: "$25M+",
     color: "#f59e0b", // amber
     description: "Full aerial platform and interceptor systems",
@@ -154,7 +154,7 @@ export const products: Product[] = [
       "Consumer-grade edge AI sensor node. Sub-200ms detection, instant mobile alerts, and blockchain-logged evidence — with an optional net-response module for active neutralisation.",
     category: "consumer",
     phase: "seed",
-    phaseTimeline: "Q2 2026 Launch • Delivery Jul 2026",
+    phaseTimeline: "Q4 2026 Launch • Delivery Jan 2027",
     available: false,
     comingSoon: true,
 
@@ -215,7 +215,7 @@ export const products: Product[] = [
       "Maker-friendly mesh sensor node with integrated response module. Pairs with any SkyWatch detector for AI-triggered, automated drone neutralisation.",
     category: "diy-maker",
     phase: "seed",
-    phaseTimeline: "Q2 2026 • Delivery Jul 2026",
+    phaseTimeline: "Q4 2026 • Delivery Jan 2027",
     available: false,
     comingSoon: true,
 
@@ -265,7 +265,7 @@ export const products: Product[] = [
       "Smart ground sensor with AI-triggered response module. Faster intercept and extended detection range — integrates with SkyWatch for fully automated targeting.",
     category: "prosumer",
     phase: "series-a",
-    phaseTimeline: "Q4 2026 • Delivery Jan 2027",
+    phaseTimeline: "Q2 2027 • Delivery Jul 2027",
     available: false,
     comingSoon: true,
 
@@ -315,7 +315,7 @@ export const products: Product[] = [
       "Precision sensor platform with pan-tilt tracking and AI-guided response. Fully autonomous operation when paired with SkyWatch Pro or Enterprise.",
     category: "commercial",
     phase: "series-a",
-    phaseTimeline: "Q2 2027 • Delivery Jul 2027",
+    phaseTimeline: "Q4 2027 • Delivery Jan 2028",
     available: false,
     comingSoon: true,
 
@@ -373,7 +373,7 @@ export const products: Product[] = [
       "Entry-level edge AI detection node. Rapid-deploy awareness for small facilities, training sites, and proof-of-concept evaluations.",
     category: "diy-maker",
     phase: "seed",
-    phaseTimeline: "Q1 2026 • Delivery Apr 2026",
+    phaseTimeline: "Q3 2026 • Delivery Oct 2026",
     available: false,
     comingSoon: true,
 
@@ -422,7 +422,7 @@ export const products: Product[] = [
       "Balanced detection system for residential use with Coral TPU acceleration and low-light capability.",
     category: "prosumer",
     phase: "seed",
-    phaseTimeline: "Q2 2026 • Delivery Jul 2026",
+    phaseTimeline: "Q4 2026 • Delivery Jan 2027",
     available: false,
     comingSoon: true,
 
@@ -471,7 +471,7 @@ export const products: Product[] = [
       "Multi-sensor detection platform with visual, RF, and audio detection. Pan-tilt tracking for professional use.",
     category: "commercial",
     phase: "seed",
-    phaseTimeline: "Q2 2026 • Delivery Jul 2026",
+    phaseTimeline: "Q4 2026 • Delivery Jan 2027",
     available: false,
     comingSoon: true,
 
@@ -520,7 +520,7 @@ export const products: Product[] = [
       "Portable detection unit for mobile operations. Battery-powered with touchscreen interface.",
     category: "prosumer",
     phase: "series-a",
-    phaseTimeline: "Q4 2026 • Delivery Jan 2027",
+    phaseTimeline: "Q2 2027 • Delivery Jul 2027",
     available: false,
     comingSoon: true,
 
@@ -569,7 +569,7 @@ export const products: Product[] = [
       "Entry-level thermal imaging detector. FLIR Lepton 3.5 (160×120) fused with visible camera for cost-effective all-light drone detection.",
     category: "commercial",
     phase: "series-a",
-    phaseTimeline: "Q1 2027 • Delivery Apr 2027",
+    phaseTimeline: "Q3 2027 • Delivery Oct 2027",
     available: false,
     comingSoon: true,
 
@@ -617,7 +617,7 @@ export const products: Product[] = [
       "Professional thermal detector. FLIR Boson 320 (320×256, 60Hz) for demanding all-light surveillance at extended range.",
     category: "commercial",
     phase: "series-a",
-    phaseTimeline: "Q1 2027 • Delivery Apr 2027",
+    phaseTimeline: "Q3 2027 • Delivery Oct 2027",
     available: false,
     comingSoon: true,
 
@@ -666,7 +666,7 @@ export const products: Product[] = [
       "Ruggedized detection system for maritime environments. Gyro stabilization and NMEA integration.",
     category: "commercial",
     phase: "series-a",
-    phaseTimeline: "Q2 2027 • Delivery Jul 2027",
+    phaseTimeline: "Q4 2027 • Delivery Jan 2028",
     available: false,
     comingSoon: true,
 
@@ -714,7 +714,7 @@ export const products: Product[] = [
       "PoE-powered mesh sensor node. Deploy multiple nodes across a wide perimeter; each node reports to the central aggregator.",
     category: "commercial",
     phase: "series-a",
-    phaseTimeline: "Q2 2027 • Delivery Jul 2027",
+    phaseTimeline: "Q4 2027 • Delivery Jan 2028",
     available: false,
     comingSoon: true,
 
@@ -763,7 +763,7 @@ export const products: Product[] = [
       "Central aggregation server for SkyWatch Mesh deployments. Fuses detections from all nodes, runs the dashboard, and connects to SOC/VMS.",
     category: "commercial",
     phase: "series-a",
-    phaseTimeline: "Q2 2027 • Delivery Jul 2027",
+    phaseTimeline: "Q4 2027 • Delivery Jan 2028",
     available: false,
     comingSoon: true,
 
@@ -812,7 +812,7 @@ export const products: Product[] = [
       "Full-scale enterprise deployment with multi-sensor integration, SOC connectivity, and compliance logging.",
     category: "enterprise",
     phase: "series-a",
-    phaseTimeline: "Q3 2027 • Delivery Aug 2027",
+    phaseTimeline: "Q1 2028 • Delivery Feb 2028",
     available: false,
     comingSoon: true,
 
@@ -865,7 +865,7 @@ export const products: Product[] = [
       "Entry-level detect-and-respond system for testing and proof-of-concept. Validates the full AI detect-to-intercept stack at maker cost.",
     category: "diy-maker",
     phase: "seed",
-    phaseTimeline: "Q3 2026 • Delivery Oct 2026",
+    phaseTimeline: "Q1 2027 • Delivery Apr 2027",
     available: false,
     comingSoon: true,
 
@@ -913,7 +913,7 @@ export const products: Product[] = [
       "AI-triggered detect-and-respond system with Coral TPU acceleration. Faster intercept, longer detection range, fully integrated in one unit.",
     category: "prosumer",
     phase: "series-a",
-    phaseTimeline: "Q1 2027 • Delivery Apr 2027",
+    phaseTimeline: "Q3 2027 • Delivery Oct 2027",
     available: false,
     comingSoon: true,
 
@@ -961,7 +961,7 @@ export const products: Product[] = [
       "Professional AI detect-and-respond platform with pan-tilt tracking, global shutter camera, and predictive targeting for high-value facilities.",
     category: "commercial",
     phase: "series-a",
-    phaseTimeline: "Q2 2027 • Delivery Jul 2027",
+    phaseTimeline: "Q4 2027 • Delivery Jan 2028",
     available: false,
     comingSoon: true,
 
@@ -1014,7 +1014,7 @@ export const products: Product[] = [
       "Full-scale enterprise drone detection and response platform with multi-sensor integration and 24/7 operations.",
     category: "enterprise",
     phase: "series-a",
-    phaseTimeline: "Q2 2027 • Delivery Jul 2027",
+    phaseTimeline: "Q4 2027 • Delivery Jan 2028",
     available: false,
     comingSoon: true,
 
@@ -1074,7 +1074,7 @@ export const products: Product[] = [
       "Centralized command and control software for multi-site drone defense coordination. Includes threat simulator for operator training.",
     category: "enterprise",
     phase: "series-a",
-    phaseTimeline: "Q1 2027 • Delivery Apr 2027",
+    phaseTimeline: "Q3 2027 • Delivery Oct 2027",
     available: false,
     comingSoon: true,
 
@@ -1138,7 +1138,7 @@ export const products: Product[] = [
       "Aerial VTOL platform serving as picket, relay, and interceptor launch platform with ducted fan design.",
     category: "military",
     phase: "series-c",
-    phaseTimeline: "Q2 2029 • Delivery Aug 2029",
+    phaseTimeline: "Q4 2029 • Delivery Feb 2030",
     available: false,
     comingSoon: true,
 
@@ -1188,7 +1188,7 @@ export const products: Product[] = [
       "Expendable/recoverable mini interceptor drone launched from RKV-M or ground station.",
     category: "military",
     phase: "series-c",
-    phaseTimeline: "Q2 2029 • Delivery Aug 2029",
+    phaseTimeline: "Q4 2029 • Delivery Feb 2030",
     available: false,
     comingSoon: true,
 
@@ -1236,7 +1236,7 @@ export const products: Product[] = [
       "Mobile ground control station and rover platform for RKV-M and RKV-I command and control.",
     category: "military",
     phase: "series-b",
-    phaseTimeline: "Q2 2028 • Delivery Aug 2028",
+    phaseTimeline: "Q4 2028 • Delivery Feb 2029",
     available: false,
     comingSoon: true,
 
@@ -1296,7 +1296,7 @@ export const products: Product[] = [
       "and 12 months of firmware updates.",
     category: "commercial" as MarketTier,
     phase: "series-a" as ProductPhase,
-    phaseTimeline: "Q1 2027",
+    phaseTimeline: "Q3 2027",
     available: false,
     comingSoon: true,
     priceRange: { min: 12000, max: 28000 },
@@ -1353,7 +1353,7 @@ export const products: Product[] = [
       "CLI for forensic export, and integration with common RMS platforms.",
     category: "enterprise" as MarketTier,
     phase: "series-a" as ProductPhase,
-    phaseTimeline: "Q2 2027",
+    phaseTimeline: "Q4 2027",
     available: false,
     comingSoon: true,
     priceRange: { min: 45000, max: 95000 },
@@ -1410,7 +1410,7 @@ export const products: Product[] = [
       "coalition operations. STANAG-compatible data formats.",
     category: "military" as MarketTier,
     phase: "series-b" as ProductPhase,
-    phaseTimeline: "Q1 2028",
+    phaseTimeline: "Q3 2028",
     available: false,
     comingSoon: true,
     priceRange: { min: 120000, max: 350000 },
@@ -1466,7 +1466,7 @@ export const products: Product[] = [
       "delivery attempts by 90%+ in pilot deployments.",
     category: "enterprise" as MarketTier,
     phase: "series-a" as ProductPhase,
-    phaseTimeline: "Q3 2027",
+    phaseTimeline: "Q1 2028",
     available: false,
     comingSoon: true,
     priceRange: { min: 55000, max: 150000 },
@@ -1522,7 +1522,7 @@ export const products: Product[] = [
       "alerts via SMS and email.",
     category: "commercial" as MarketTier,
     phase: "series-a" as ProductPhase,
-    phaseTimeline: "Q2 2027",
+    phaseTimeline: "Q4 2027",
     available: false,
     comingSoon: true,
     priceRange: { min: 3500, max: 8000 },
@@ -1578,7 +1578,7 @@ export const products: Product[] = [
       "security reports for venue compliance.",
     category: "commercial" as MarketTier,
     phase: "series-a" as ProductPhase,
-    phaseTimeline: "Q4 2027",
+    phaseTimeline: "Q2 2028",
     available: false,
     comingSoon: true,
     priceRange: { min: 2500, max: 15000 },
@@ -1634,7 +1634,7 @@ export const products: Product[] = [
       "existing bridge radar and AIS systems.",
     category: "enterprise" as MarketTier,
     phase: "series-b" as ProductPhase,
-    phaseTimeline: "Q2 2028",
+    phaseTimeline: "Q4 2028",
     available: false,
     comingSoon: true,
     priceRange: { min: 75000, max: 200000 },


### PR DESCRIPTION
## Summary
- **Layout/alignment**: removed the global `section:first-of-type` top-padding bump in `globals.css`. The nav is sticky (in-flow), so first sections need no clearance — and the rule's (0,1,1) specificity silently beat CSS-module section classes, adding ~136px of dead space above the hero and the first section of every page.
- **Contact page**: the "Request Intro Call" button used an amber→slate gradient with near-black text (unreadable on the dark card); now solid amber matching the site-wide primary Button. The full-width "Get in Touch" card now spreads its three contact channels into columns on desktop instead of stacking them beside dead space.
- **Timing (2 quarters behind)**: shifted all forward-looking ship/delivery/certification dates +2 quarters — 50 lines across products data, hero, announcement bar, homepage FAQ/JSON-LD, roadmap milestones, preorder FAQ, SBIR compliance roadmap, ISO-27001 badges, unit economics. Kestrel Mesh now ships Q1 2027.

Left alone deliberately: TimelineSection fiscal-year phase buckets (calendar-fixed; the shift incidentally fixes the FAA-waiver milestone that previously predated its own FY27 phase), legal effective dates, and the competitors pricing-as-of note.

## Verification
- `tsc --noEmit` passes for apps/marketing
- Root cause of the 136px gap confirmed by DOM inspection on the live site (computed padding-top vs. matched CSS rules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)