### PR TITLE
fix(ci): deploy main pushes to real SWA production slot

### DIFF
--- a/.github/workflows/deploy-marketing-azure.yml
+++ b/.github/workflows/deploy-marketing-azure.yml
@@ -178,10 +178,13 @@ jobs:
           app_location: ${{ env.MARKETING_APP_DIR }}/out
           skip_app_build: true
           skip_api_build: true
-          # Production deploys go to production slot, PR deploys create preview environments
+          # Leave deployment_environment unset: in this action a BLANK value
+          # targets the real production slot, while any non-empty value
+          # creates a NAMED preview environment — a literal 'production'
+          # value shipped main pushes to jolly-beach-...-production.westeurope
+          # instead of production. PR events still get auto-named previews
+          # via repo_token.
           production_branch: main
-          deployment_environment:
-            ${{ github.event_name == 'push' && 'production' || '' }}
 
       - name: Comment on PR with preview URL
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
Follow-up to #860. The SWA deploy action treats a **blank** `deployment_environment` as the production slot; any non-empty value creates a named preview environment. The push branch set the literal string `production`, so every merge to main deployed to `jolly-beach-...-production.westeurope.7.azurestaticapps.net` while the real production slot stayed stale — #860's content only reached nexamesh.ai via a manual `workflow_dispatch` (which resolved the expression to `''`).

This removes the parameter so pushes hit real production; PR previews are unaffected (auto-named via `repo_token`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)